### PR TITLE
Miscellaneous updates for direct access lib 0.12.0

### DIFF
--- a/dependencies/direct_access_client/Cargo.toml
+++ b/dependencies/direct_access_client/Cargo.toml
@@ -5,7 +5,7 @@ description = "Direct Access API client library for Rust"
 repository.workspace = true
 license.workspace = true
 rust-version.workspace = true
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 
 [features]

--- a/dependencies/direct_access_client/app/backend/Cargo.toml
+++ b/dependencies/direct_access_client/app/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/Qiskit/direct-access-client"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ pulse_defaults = []
 
 [dependencies]
 direct-access-api = { workspace = true }
-retry-policies = "0.4.0"
+reqwest-retry = "0.7.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde_json = "1.0"

--- a/dependencies/direct_access_client/app/cancel_job/Cargo.toml
+++ b/dependencies/direct_access_client/app/cancel_job/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "cancel_job"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/Qiskit/direct-access-client"
 license = "Apache-2.0"
 
 [dependencies]
 direct-access-api = { workspace = true }
-retry-policies = "0.4.0"
+reqwest-retry = "0.7.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde_json = "1.0"

--- a/dependencies/direct_access_client/app/delete_job/Cargo.toml
+++ b/dependencies/direct_access_client/app/delete_job/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "delete_job"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/Qiskit/direct-access-client"
 license = "Apache-2.0"
 
 [dependencies]
 direct-access-api = { workspace = true }
-retry-policies = "0.4.0"
+reqwest-retry = "0.7.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde_json = "1.0"

--- a/dependencies/direct_access_client/app/job_details/Cargo.toml
+++ b/dependencies/direct_access_client/app/job_details/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "job_details"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/Qiskit/direct-access-client"
 license = "Apache-2.0"
 
 [dependencies]
 direct-access-api = { workspace = true }
-retry-policies = "0.4.0"
+reqwest-retry = "0.7.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde_json = "1.0"

--- a/dependencies/direct_access_client/app/list_jobs/Cargo.toml
+++ b/dependencies/direct_access_client/app/list_jobs/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 direct-access-api = { workspace = true }
-retry-policies = "0.4.0"
+reqwest-retry = "0.7.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde_json = "1.0"

--- a/dependencies/direct_access_client/app/run_job/Cargo.toml
+++ b/dependencies/direct_access_client/app/run_job/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "run_job"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/Qiskit/direct-access-client"
 license = "Apache-2.0"
 
 [dependencies]
 direct-access-api = { workspace = true }
-retry-policies = "0.4.0"
+reqwest-retry = "0.7.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde_json = "1.0"

--- a/dependencies/direct_access_client/app/run_primitive/Cargo.toml
+++ b/dependencies/direct_access_client/app/run_primitive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "run_primitive"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
 direct-access-api = { workspace = true }
-retry-policies = "0.4.0"
+reqwest-retry = "0.7.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde_json = "1.0"

--- a/dependencies/direct_access_client/src/api/run_primitive.rs
+++ b/dependencies/direct_access_client/src/api/run_primitive.rs
@@ -134,15 +134,20 @@ impl Client {
             }
         };
 
-        let input_presigned_url =
-            crate::storages::s3::get_presigned_url(&s3_client_remote, &s3_bucket, &job_param_key)
-                .await?;
+        let input_presigned_url = crate::storages::s3::get_presigned_url(
+            &s3_client_remote,
+            &s3_bucket,
+            &job_param_key,
+            timeout_secs,
+        )
+        .await?;
 
         let results_key = format!("{}{}.json", S3KEY_RESULTS_PREFIX, id);
         let results_presigned_url = crate::storages::s3::get_presigned_url_for_put(
             &s3_client_remote,
             &s3_bucket,
             &results_key,
+            timeout_secs,
         )
         .await?;
 
@@ -151,6 +156,7 @@ impl Client {
             &s3_client_remote,
             &s3_bucket,
             &logs_key,
+            timeout_secs,
         )
         .await?;
 
@@ -250,7 +256,8 @@ impl PrimitiveJob {
 
         let key = format!("{}{}.json", S3KEY_RESULTS_PREFIX, self.job_id);
         let presigned_url =
-            crate::storages::s3::get_presigned_url(&self.s3_client, &self.s3_bucket, &key).await?;
+            crate::storages::s3::get_presigned_url(&self.s3_client, &self.s3_bucket, &key, 3600)
+                .await?;
         debug!("{}", presigned_url);
 
         let client = reqwest::Client::new();
@@ -328,7 +335,8 @@ impl PrimitiveJob {
 
         let key = format!("{}{}.json", S3KEY_LOGS_PREFIX, self.job_id);
         let presigned_url =
-            crate::storages::s3::get_presigned_url(&self.s3_client, &self.s3_bucket, &key).await?;
+            crate::storages::s3::get_presigned_url(&self.s3_client, &self.s3_bucket, &key, 3600)
+                .await?;
         debug!("{}", presigned_url);
 
         let client = reqwest::Client::new();

--- a/dependencies/direct_access_client/src/storages/s3.rs
+++ b/dependencies/direct_access_client/src/storages/s3.rs
@@ -1,5 +1,5 @@
 //
-// (C) Copyright IBM 2024
+// (C) Copyright IBM 2024, 2025
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -23,8 +23,13 @@ use aws_sdk_s3::error::ProvideErrorMetadata;
 /// * `bucket_name` - S3 bucket name.
 /// * `key` - S3 object key.
 ///     
-pub async fn get_presigned_url(client: &Client, bucket_name: &str, key: &str) -> Result<String> {
-    let expires_in = Duration::from_secs(3600);
+pub async fn get_presigned_url(
+    client: &Client,
+    bucket_name: &str,
+    key: &str,
+    expiration: u64,
+) -> Result<String> {
+    let expires_in = Duration::from_secs(expiration);
     let presigned_config = PresigningConfig::expires_in(expires_in)?;
     let presigned_url = match client
         .get_object()
@@ -53,8 +58,9 @@ pub async fn get_presigned_url_for_put(
     client: &Client,
     bucket_name: &str,
     obj_key: &str,
+    expiration: u64,
 ) -> Result<String> {
-    let expires_in = Duration::from_secs(3600);
+    let expires_in = Duration::from_secs(expiration);
     let presigned_config = PresigningConfig::expires_in(expires_in)?;
     let presigned_url = match client
         .put_object()


### PR DESCRIPTION
- Fix build breaks of dependencies/direct_access/app examples
- Remove hard-coded value of S3 presigned url expiration.
- Update direct-access-client crate version to 0.13.0