### PR TITLE
[FEAT] Enable access to all QPUs on Pasqal Cloud

### DIFF
--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -40,6 +40,7 @@ pub struct Response<T> {
 #[derive(Debug, Clone, Deserialize)]
 pub struct GetDeviceResponseData {
     pub status: String,
+    pub availability: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -82,13 +83,19 @@ impl Client {
     pub async fn get_device(
         &self,
         device_type: DeviceType,
-    ) -> Result<Response<GetDeviceResponseData>> {
+    ) -> Result<GetDeviceResponseData> {
         let url = format!(
             "{}/core-fast/api/v1/devices?device_type={}",
             self.base_url, device_type,
         );
-        self.get(&url).await
+        let resp: Response<Vec<GetDeviceResponseData>> = self.get(&url).await?;
+
+        resp.data
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No devices found for type {:?}", device_type))
     }
+
     /// Pasqal Cloud works with batches of jobs rather than
     /// individual jobs, see:
     /// https://docs.pasqal.com/cloud/batches/

--- a/dependencies/pasqal_cloud_client/src/models/device.rs
+++ b/dependencies/pasqal_cloud_client/src/models/device.rs
@@ -13,11 +13,13 @@
 use serde::{Deserialize, Serialize};
 
 use std::fmt;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all(serialize = "UPPERCASE"))]
 pub enum DeviceType {
     Fresnel,
+    Fresnel_Can1,
     EmuMps,
     EmuFree,
 }
@@ -26,9 +28,25 @@ impl fmt::Display for DeviceType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match self {
             DeviceType::Fresnel => "FRESNEL",
+            DeviceType::Fresnel_Can1 => "FRESNEL_CAN1",
             DeviceType::EmuMps => "EMU_MPS",
             DeviceType::EmuFree => "EMU_FREE",
         };
         write!(f, "{}", name)
     }
 }
+
+impl FromStr for DeviceType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "FRESNEL" => Ok(DeviceType::Fresnel),
+            "FRESNEL_CAN1" => Ok(DeviceType::Fresnel_Can1),
+            "EMU_MPS" => Ok(DeviceType::EmuMps),
+            "EMU_FREE" => Ok(DeviceType::EmuFree),
+            _ => Err(()),
+        }
+    }
+}
+

--- a/examples/pulser_backend/pasqal/target.py
+++ b/examples/pulser_backend/pasqal/target.py
@@ -21,7 +21,7 @@ import pulser
 import pulser.abstract_repr
 from dotenv import load_dotenv
 from pulser.devices import Device
-from pulser_qrmi_backend.service import QRMIService
+from qrmi.pulser_backend.service import QRMIService
 
 from qrmi import QuantumResource
 

--- a/python/qrmi/pulser_backend/service.py
+++ b/python/qrmi/pulser_backend/service.py
@@ -45,20 +45,20 @@ class QRMIService:
         self._qrmi_resources = {}
         for i, qpu in enumerate(qpus):
             qpu = qpu.strip()
-            qrmi = None
+            resource = None
             if qpu_types[i] == "direct-access":
-                qrmi = QuantumResource(qpu, ResourceType.IBMDirectAccess)
+                resource = QuantumResource(qpu, ResourceType.IBMDirectAccess)
             elif qpu_types[i] == "qiskit-runtime-service":
-                qrmi = QuantumResource(qpu, ResourceType.IBMQiskitRuntimeService)
+                resource = QuantumResource(qpu, ResourceType.IBMQiskitRuntimeService)
             elif qpu_types[i] == "pasqal-cloud":
-                qrmi = QuantumResource(qpu, ResourceType.PasqalCloud)
+                resource = QuantumResource(qpu, ResourceType.PasqalCloud)
             else:
                 logger.warning(
                     "Unsupported resource type: %s specified for %s", qpu_types[i], qpu
                 )
 
-            if qrmi.is_accessible() is False:
-                self._qrmi_resources[qpu] = qrmi
+            if resource.is_accessible():
+                self._qrmi_resources[qpu] = resource
             else:
                 logger.debug("%s is not accessible now. ignored.", qpu)
 

--- a/src/pasqal/cloud.rs
+++ b/src/pasqal/cloud.rs
@@ -43,12 +43,14 @@ impl PasqalCloud {
                     "{backend_name}_QRMI_PASQAL_CLOUD_PROJECT_ID environment variable is not set"
                 )
             })?;
-        let auth_token =
-            env::var(format!("{backend_name}_QRMI_PASQAL_CLOUD_AUTH_TOKEN")).map_err(|_| {
-                anyhow!(
-                    "{backend_name}_QRMI_PASQAL_CLOUD_AUTH_TOKEN environment variable is not set"
-                )
-            })?;
+        // Allow empty tokens: some devices are public on Pasqal Cloud
+        // so their specs can be queried without a token
+        let var_name = format!("{backend_name}_QRMI_PASQAL_CLOUD_AUTH_TOKEN");
+        let auth_token = env::var(&var_name).unwrap_or_else(|_| {
+            eprintln!("Warning: {var_name} is not set; proceeding with empty auth token.");
+            String::new()
+        });
+
         Ok(Self {
             api_client: ClientBuilder::new(auth_token, project_id).build().unwrap(),
             backend_name: backend_name.to_string(),
@@ -59,19 +61,26 @@ impl PasqalCloud {
 #[async_trait]
 impl QuantumResource for PasqalCloud {
     async fn is_accessible(&mut self) -> Result<bool> {
-        let fresnel = DeviceType::Fresnel.to_string();
-        if self.backend_name != fresnel {
-            let err = format!(
-                "Device {} is invalid. Only {} device can receive jobs.",
-                self.backend_name, fresnel,
-            );
-            bail!(format!("{}", &err));
-        };
-        match self.api_client.get_device(DeviceType::Fresnel).await {
-            Ok(device) => Ok(device.data.status == "UP"),
-            Err(err) => {
-                bail!(format!("Failed to get device: {}", &err));
+        let device_type = match self.backend_name.parse::<DeviceType>() {
+            Ok(dt) => dt,
+            Err(_) => {
+                // Inline valid devices directly
+                let valid_devices = vec!["FRESNEL", "FRESNEL_CAN1", "EMU_MPS", "EMU_FREE"];
+                let err = format!(
+                    "Device '{}' is invalid. Valid devices: {}",
+                    self.backend_name,
+                    valid_devices.join(", ")
+                );
+                bail!(err);
             }
+        };
+
+        // The device may be down temporarily but jobs can still
+        // be submitted and queued through the cloud
+        // Thus we only check that the device is not retired 
+        match self.api_client.get_device(device_type).await {
+            Ok(device) => Ok(device.availability == "ACTIVE"),
+            Err(err) => bail!("Failed to get device: {}", err),
         }
     }
 
@@ -89,10 +98,22 @@ impl QuantumResource for PasqalCloud {
 
     async fn task_start(&mut self, payload: Payload) -> Result<String> {
         if let Payload::PasqalCloud { sequence, job_runs } = payload {
-            // TODO: Make configurable (get emulator from qrmi)
+            let device_type = match self.backend_name.parse::<DeviceType>() {
+                Ok(dt) => dt,
+                Err(_) => {
+                    let valid_devices = vec!["FRESNEL", "FRESNEL_CAN1", "EMU_MPS", "EMU_FREE"];
+                    let err = format!(
+                        "Device '{}' is invalid. Valid devices: {}",
+                        self.backend_name,
+                        valid_devices.join(", ")
+                    );
+                    bail!(err);
+                }
+            };
+
             match self
                 .api_client
-                .create_batch(sequence, job_runs, DeviceType::EmuFree)
+                .create_batch(sequence, job_runs, device_type)
                 .await
             {
                 Ok(batch) => Ok(batch.data.id),
@@ -141,19 +162,24 @@ impl QuantumResource for PasqalCloud {
     }
 
     async fn target(&mut self) -> Result<Target> {
-        let fresnel = DeviceType::Fresnel.to_string();
-        if self.backend_name != fresnel {
-            let err = format!(
-                "Device {} is invalid. Only {} device can receive jobs.",
-                self.backend_name, fresnel
-            );
-            panic!("{}", err);
+        let device_type = match self.backend_name.parse::<DeviceType>() {
+            Ok(dt) => dt,
+            Err(_) => {
+                let valid_devices = vec!["FRESNEL", "FRESNEL_CAN1", "EMU_MPS", "EMU_FREE"];
+                let err = format!(
+                    "Device '{}' is invalid. Valid devices: {}",
+                    self.backend_name,
+                    valid_devices.join(", ")
+                );
+                panic!("{}", err);
+            }
         };
-        match self.api_client.get_device_specs(DeviceType::Fresnel).await {
+
+        match self.api_client.get_device_specs(device_type).await {
             Ok(resp) => Ok(Target {
                 value: resp.data.specs,
             }),
-            Err(_err) => Err(_err),
+            Err(err) => Err(err),
         }
     }
 


### PR DESCRIPTION
Let users submit jobs to pasqal cloud QPUs FRESNEL and FRESNEL_CAN1 through the QRMI plugin.

In the process we fixed a few bugs for the pasal cloud integration for the newer versions of the QRMI.

Main changes:
- remove hard-coded reference to EMU_FREE when submitting a job. Now we properly target the backend targetted by the user using the dedicated `--qpu` sbatch option
- add FRESNEL_CAN1 and EMU_FRESNEL to DeviceType enum
- change logic for `is_accessible` to be based on the availability of the qpu/emu instead of its live status.
- make auth token env variable optional in spank plugin, as it doesn't prevent fetching public device specs. The auth middleware is not ready just yet so this lets us define the token at runtime without crashing the qrmi.

Users can now freely target Fresnel, Fresnel_Can1, EMU_FREE and EMU_MPS with sbatch using `#SBATCH --qpu=<backend>`.
