### PR TITLE
Remove pathlib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
   "pulser>=1.5.3",
   "python-dotenv",
   "python-dateutil",
-  "pathlib",
 ]
 [project.urls]
 repository = "https://github.com/qiskit-community/spank-plugins"


### PR DESCRIPTION
In a recent [commit](https://github.com/qiskit-community/qrmi/commit/7281cc06b451cdc02b90ccfbaca93fb0dcdc934a), the "pathlib" dependency  has been added to the pyproject.toml. I believe this is a mistake, since pathlib is a [builtin python package](https://docs.python.org/3/library/pathlib.html) added in python3.4. On the other hand the [pathlib package has not been updated in over 10 years](https://pypi.org/project/pathlib/) and is not compatible with recent python versions.

This causes some runtime errors reported by Cineca when running the QRMI. Getting rid of the package solves the issue.

