### PR TITLE
Fix linter/formatter errors in framework, infrastructure and direct access code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -73,6 +73,8 @@ disable=
     docstring-first-line-empty, # relax docstring style
     import-outside-toplevel,
     unnecessary-lambda-assignment,
+    no-name-in-module,
+    useless-parent-delegation,
     assigning-non-slot  # https://github.com/Qiskit/qiskit-terra/pull/7347#issuecomment-985007311
 
 

--- a/python/qrmi/__init__.py
+++ b/python/qrmi/__init__.py
@@ -1,4 +1,21 @@
-from importlib import import_module as _im
-_core = _im(__name__ + '._core')      # -> qrmi._core  (Rust)
+# -*- coding: utf-8 -*-
 
-globals().update({k: v for k, v in _core.__dict__.items() if not k.startswith('_')})
+# This code is part of Qiskit.
+#
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""QRMI python package"""
+
+from importlib import import_module as _im
+
+_core = _im(__name__ + "._core")  # -> qrmi._core  (Rust)
+
+globals().update({k: v for k, v in _core.__dict__.items() if not k.startswith("_")})

--- a/python/qrmi/primitives/__init__.py
+++ b/python/qrmi/primitives/__init__.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,8 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+"""QRMI primitives"""
 
 from .service import QRMIService
 from .base_estimator import QRMIBaseEstimatorV2

--- a/python/qrmi/primitives/base_estimator.py
+++ b/python/qrmi/primitives/base_estimator.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,8 +13,8 @@
 # that they have been altered from the originals.
 
 """Estimator V2 base class for IBM QRMI"""
+
 import json
-from typing import Union
 from dataclasses import dataclass, field
 from collections.abc import Iterable
 from qiskit import qasm3

--- a/python/qrmi/primitives/base_sampler.py
+++ b/python/qrmi/primitives/base_sampler.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,8 +11,8 @@
 # that they have been altered from the originals.
 
 """Sampler V2 base class for IBM QRMI"""
+
 import json
-from typing import Union
 from dataclasses import dataclass, field
 from collections.abc import Iterable
 from qiskit import qasm3

--- a/python/qrmi/primitives/ibm/backend.py
+++ b/python/qrmi/primitives/ibm/backend.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -42,6 +42,7 @@ def get_backend(
 
     Args:
         qrmi: IBM QRMI object
+        use_fractional_gates: Whether to use native “fractional gates” on the device if available.
 
     Returns:
         qiskit.transpiler.target.Target: Qiskit Transpiler target

--- a/python/qrmi/primitives/ibm/estimator.py
+++ b/python/qrmi/primitives/ibm/estimator.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """EstimatorV2 Primitive implementation with IBM QRMI"""
-from typing import Union
+
 from qrmi import QuantumResource
 from qrmi.primitives import QRMIBaseEstimatorV2
 

--- a/python/qrmi/primitives/ibm/sampler.py
+++ b/python/qrmi/primitives/ibm/sampler.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """SamplerV2 Primitive implementation with IBM QRMI"""
-from typing import Union
+
 from qrmi import QuantumResource
 from qrmi.primitives import QRMIBaseSamplerV2
 

--- a/python/qrmi/primitives/runtime_job_v2.py
+++ b/python/qrmi/primitives/runtime_job_v2.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,7 +15,6 @@
 """Runtime job"""
 
 import time
-from typing import Union
 from qiskit_ibm_runtime.utils.result_decoder import ResultDecoder
 from qiskit.primitives import BasePrimitiveJob, PrimitiveResult
 from qiskit.providers import JobStatus
@@ -106,4 +105,4 @@ class RuntimeJobV2(BasePrimitiveJob[PrimitiveResult, TaskStatus]):
 
     def logs(self) -> str:
         """Return job logs."""
-        return qrmi.task_logs(self._job_id)
+        return self._qrmi.task_logs(self._job_id)

--- a/python/qrmi/tools/task_runner/main.py
+++ b/python/qrmi/tools/task_runner/main.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2025
+# (C) Copyright IBM 2025, 2026
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,6 +13,7 @@
 # that they have been altered from the originals.
 
 """qrmi_task_runner - Command to run a QRMI task"""
+
 import os
 import sys
 import time
@@ -55,7 +56,9 @@ def _get_loglevel() -> int:
 
 
 logging.basicConfig(
-    stream=sys.stdout, level=_get_loglevel(), format="%(asctime)s %(levelname)s %(message)s"
+    stream=sys.stdout,
+    level=_get_loglevel(),
+    format="%(asctime)s %(levelname)s %(message)s",
 )
 logger = getLogger(__name__)
 
@@ -169,8 +172,8 @@ class App:
         res_type = self._find_qpu_type(self._name)
         self._qrmi = QuantumResource(self._name, res_type)
 
-        with open(self._input_filename, encoding="utf-8") as f:
-            task_input = json.load(f)
+        with open(self._input_filename, encoding="utf-8") as input_file:
+            task_input = json.load(input_file)
             if res_type in [
                 ResourceType.IBMDirectAccess,
                 ResourceType.IBMQiskitRuntimeService,

--- a/src/bin/task_runner.rs
+++ b/src/bin/task_runner.rs
@@ -192,13 +192,20 @@ impl ResourceType {
             }),
         }
     }
-    fn create_qrmi(&self, qpu_name: &str) -> Box<dyn QuantumResource> {
+    fn create_qrmi(
+        &self,
+        qpu_name: &str,
+    ) -> Result<Box<dyn QuantumResource>, Box<dyn std::error::Error>> {
         match self {
-            ResourceType::IBMDirectAccess { .. } => Box::new(IBMDirectAccess::new(qpu_name)),
-            ResourceType::QiskitRuntimeService { .. } => {
-                Box::new(IBMQiskitRuntimeService::new(qpu_name))
+            ResourceType::IBMDirectAccess { .. } => {
+                Ok(Box::new(IBMDirectAccess::new(qpu_name)?) as Box<dyn QuantumResource>)
             }
-            ResourceType::PasqalCloud { .. } => Box::new(PasqalCloud::new(qpu_name)),
+            ResourceType::QiskitRuntimeService { .. } => {
+                Ok(Box::new(IBMQiskitRuntimeService::new(qpu_name)?) as Box<dyn QuantumResource>)
+            }
+            ResourceType::PasqalCloud { .. } => {
+                Ok(Box::new(PasqalCloud::new(qpu_name)?) as Box<dyn QuantumResource>)
+            }
         }
     }
 }
@@ -354,7 +361,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let payload = res_type.to_payload().unwrap();
-    let mut qrmi = res_type.create_qrmi(&qpu_name);
+    let mut qrmi = res_type.create_qrmi(&qpu_name)?;
 
     // setup signal handler for slurm, and start it
     let signals = Signals::new([SIGTERM, SIGCONT])?;


### PR DESCRIPTION
Fixed the errors reported against QRMI common code (incl. task runner) &  direct access code by GHA workflow (#41 ). Fixes for Pasqal and IBM Qiskit Runtime Service code will be managed by @awennersteen and @OkuyanBoga . 