### PR TITLE
qiskit-runtime-service: Display session status correctly on IQP Web

### DIFF
--- a/src/ibm/qiskit_runtime_service.rs
+++ b/src/ibm/qiskit_runtime_service.rs
@@ -224,13 +224,13 @@ impl QuantumResource for IBMQiskitRuntimeService {
 
         // Determine if this session should be canceled or just closed
         let mut do_cancel = false;
-        // Obtain a list of jobs associated with this session(acqisition)
+        // Obtain a list of jobs associated with this session(acquisition)
         let jobs_resp = jobs_api::list_jobs(
             &self.config,
             None,
             None,
             None,
-            Some(true),
+            Some(true), // pending jobs only
             None,
             None,
             None,


### PR DESCRIPTION
The behavior described in #49 has been repeatedly pointed out by users and has caused confusion for a long time. This PR addresses the issue and ensures that the session status is displayed correctly.

## Current Behavior:
In the current Qiskit Runtime Service (QRMI), a session is closed using the [“Close job session” API](https://quantum.cloud.ibm.com/docs/en/api/qiskit-runtime-rest/tags/sessions#tags__sessions__operations__delete_session_close) provided by the Qiskit Runtime REST API. However, although the API documentation describes this operation as “Close,” its actual behavior corresponds to Qiskit’s cancel-job operation. As a result, regardless of whether the job completes successfully, invoking this API causes the session to appear as “Cancelled” on the IQP web interface.

## Expected Behavior:
When a quantum job is in a pending state (Queued, Running) and the user performs a cancel operation such as `scancel`, the session status should be shown as “Cancelled.” In all other cases — including successful completion and errors — the session should be shown as “Completed.”

<img width="2525" height="81" alt="スクリーンショット 2026-02-23 22 31 20" src="https://github.com/user-attachments/assets/2fad1b92-cd2d-45fc-8892-605a6ce7ad7f" />
<img width="2526" height="77" alt="スクリーンショット 2026-02-23 22 31 46" src="https://github.com/user-attachments/assets/dc9aa167-b795-4362-aef7-b0e8997e5375" />



## Note:
The implementation for setting the status to “Completed” follows [the behavior of qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime/blob/e493ae0f3ad84a181305a6a513ba519878dfc86b/qiskit_ibm_runtime/api/rest/runtime_session.py#L68-L78).