### PR TITLE
[FIX] Pasqal Cloud - Authenticate request to get device specs endpoint

### DIFF
--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -298,13 +298,12 @@ impl Client {
         &mut self,
         device_type: DeviceType,
     ) -> Result<Response<GetDeviceSpecsResponseData>> {
-        // Not authenticated
         let url = format!(
             "{}/core-fast/api/v1/devices/specs/{}",
             self.base_url, device_type
         );
-        let resp = self.client.get(&url).send().await?;
-        self.handle_request(resp).await
+        let resp: Response<GetDeviceSpecsResponseData> = self.get(&url).await?;
+        Ok(resp)
     }
 
     pub(crate) async fn get<T: DeserializeOwned>(&mut self, url: &str) -> Result<T> {


### PR DESCRIPTION
## Description of Change

Some testing from @badtst revealed the `target` calls were failing with 401 requests in pasqal cloud QRMI implementation. By using the method of the client we ensure the request headers with the JWT are attached to the HTTP request. 

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
