### PR TITLE
Fix Rust doctest errors

### DIFF
--- a/src/cext.rs
+++ b/src/cext.rs
@@ -117,13 +117,15 @@ fn _set_last_error(msg: String) {
 ///
 /// # Example
 ///
-///     char *target = NULL;
-///     QrmiReturnCode rc;
-///     rc = qrmi_resource_target(qrmi, &target);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///         printf("target = %s\n", target);
-///         qrmi_string_free(target);
-///     }
+/// @code
+///   char *target = NULL;
+///   QrmiReturnCode rc;
+///   rc = qrmi_resource_target(qrmi, &target);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     printf("target = %s\n", target);
+///     qrmi_string_free(target);
+///   }
+/// @endcode
 ///
 /// @param (ptr) [in] pointer to the memory to be free
 /// @return @ref QrmiReturnCode::QRMI_RETURN_CODE_SUCCESS if succeeded.
@@ -149,15 +151,17 @@ pub unsafe extern "C" fn qrmi_string_free(ptr: *mut c_char) -> ReturnCode {
 ///
 /// # Example
 ///
-///       size_t num_names = 0;
-///       char **names = NULL;
-///       QrmiReturnCode rc = qrmi_config_resource_names_get(cnf, &num_names, &names);
-///       if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///           for (int i = 0; i < num_names; i++) {
-///               printf("[%s]\n", names[i]);
-///           }
-///           qrmi_string_array_free(num_names, names);
-///       }
+/// @code
+///   size_t num_names = 0;
+///   char **names = NULL;
+///   QrmiReturnCode rc = qrmi_config_resource_names_get(cnf, &num_names, &names);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     for (int i = 0; i < num_names; i++) {
+///       printf("[%s]\n", names[i]);
+///     }
+///     qrmi_string_array_free(num_names, names);
+///   }
+/// @endcode
 ///
 /// @param (size) [in] number of strings in a string array
 /// @param (array) [in] a pointer to a string array to be free
@@ -197,7 +201,9 @@ pub unsafe extern "C" fn qrmi_string_array_free(
 ///
 /// # Example
 ///
-///     QrmiConfig *cnf = qrmi_config_load("/etc/slurm/qrmi_config.json");
+/// @code
+///   QrmiConfig *cnf = qrmi_config_load("/etc/slurm/qrmi_config.json");
+/// @endcode
 ///
 /// @param (filename) [in] qrmi_config.json file path
 /// @return A QrmiConfig if succeeded, otherwise NULL. Must call qrmi_config_free() to free if no longer used.
@@ -230,8 +236,10 @@ pub unsafe extern "C" fn qrmi_config_load(filename: *const c_char) -> *mut Confi
 ///
 /// # Example
 ///
-///     QrmiConfig *cnf = qrmi_config_load("/etc/slurm/qrmi_config.json");
-///     qrmi_config_free(cnf);
+/// @code
+///   QrmiConfig *cnf = qrmi_config_load("/etc/slurm/qrmi_config.json");
+///   qrmi_config_free(cnf);
+/// @endcode
 ///
 /// @param (ptr) a pointer to Config to be free
 /// @return @ref QrmiReturnCode::QRMI_RETURN_CODE_SUCCESS if succeeded.
@@ -259,18 +267,20 @@ pub unsafe extern "C" fn qrmi_config_free(ptr: *mut Config) -> ReturnCode {
 ///
 /// # Example
 ///
-///     QrmiConfig *cnf = qrmi_config_load(argv[1]);
-///     if (!cnf) {
-///         QrmiResourceDef* res = qrmi_config_resource_def_get(cnf, "your_resource_id");
-///         if (res != NULL) {
-///             printf("%s %d\n", res->name, res->type);
-///             QrmiEnvironmentVariables envvars = res->environments;
-///             for (int j = 0; j < envvars.length; j++) {
-///                 QrmiKeyValue envvar = envvars.variables[j];
-///                 printf("%s = %s\n", envvar.key, envvar.value);
-///             }
-///         }
+/// @code
+///   QrmiConfig *cnf = qrmi_config_load(argv[1]);
+///   if (!cnf) {
+///     QrmiResourceDef* res = qrmi_config_resource_def_get(cnf, "your_resource_id");
+///     if (res != NULL) {
+///       printf("%s %d\n", res->name, res->type);
+///       QrmiEnvironmentVariables envvars = res->environments;
+///       for (int j = 0; j < envvars.length; j++) {
+///         QrmiKeyValue envvar = envvars.variables[j];
+///         printf("%s = %s\n", envvar.key, envvar.value);
+///       }
 ///     }
+///   }
+/// @endcode
 ///
 /// @param (config) [in] a Config handle
 /// @param (resource_id) [in] resource identifier
@@ -322,8 +332,10 @@ pub unsafe extern "C" fn qrmi_config_resource_def_get(
 ///
 /// # Example
 ///
-///      char *type_as_str = qrmi_config_resource_type_to_str(QRMI_RESOURCE_TYPE_QISKIT_RUNTIME_SERVICE):
-///      printf("%s\n", type_as_str);
+/// @code
+///   char *type_as_str = qrmi_config_resource_type_to_str(QRMI_RESOURCE_TYPE_QISKIT_RUNTIME_SERVICE):
+///   printf("%s\n", type_as_str);
+/// @endcode
 ///
 /// @param type (QrmiResourceType) ResourceType variant
 /// @return string representation of ResourceType.
@@ -346,14 +358,16 @@ pub unsafe extern "C" fn qrmi_config_resource_type_to_str(r#type: ResourceType) 
 ///
 /// # Example
 ///
-///     QrmiConfig *cnf = qrmi_config_load(argv[1]);
-///     if (!cnf) {
-///         QrmiResourceDef* res = qrmi_config_resource_def_get(cnf, "your_resource_id");
-///         if (res != NULL) {
-///             printf("%s %d\n", res->name, res->type);
-///         }
-///         qrmi_config_resource_def_free(res);
+/// @code
+///   QrmiConfig *cnf = qrmi_config_load(argv[1]);
+///   if (!cnf) {
+///     QrmiResourceDef* res = qrmi_config_resource_def_get(cnf, "your_resource_id");
+///     if (res != NULL) {
+///       printf("%s %d\n", res->name, res->type);
 ///     }
+///     qrmi_config_resource_def_free(res);
+///   }
+/// @endcode
 ///     
 /// @param (ptr) a pointer to ResourceDef to be free
 /// @return @ref QrmiReturnCode::QRMI_RETURN_CODE_SUCCESS if succeeded.
@@ -399,15 +413,17 @@ pub unsafe extern "C" fn qrmi_config_resource_def_free(ptr: *mut ResourceDef) ->
 ///
 /// # Example
 ///
-///      size_t num_names = 0;
-///      char **names = NULL;
-///      QrmiReturnCode rc = qrmi_config_resource_names_get(cnf, &num_names, &names);
-///      if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///          for (int i = 0; i < num_names; i++) {
-///              printf("[%s]\n", names[i]);
-///          }
-///          qrmi_string_array_free(num_names, names);
-///      }
+/// @code
+///   size_t num_names = 0;
+///   char **names = NULL;
+///   QrmiReturnCode rc = qrmi_config_resource_names_get(cnf, &num_names, &names);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     for (int i = 0; i < num_names; i++) {
+///       printf("[%s]\n", names[i]);
+///     }
+///     qrmi_string_array_free(num_names, names);
+///   }
+/// @endcode
 ///
 /// @param (config) [in] A Config handle
 /// @param (num_names) [out] number of resource names in the list
@@ -462,11 +478,13 @@ pub unsafe extern "C" fn qrmi_config_resource_names_get(
 ///
 /// # Example
 ///
-///     const char * last_error = qrmi_get_last_error();
-///     if (last_error != NULL) {
-///         printf("last error = %s\n", last_error);
-///         qrmi_string_free(last_error);
-///     }
+/// @code
+///   const char * last_error = qrmi_get_last_error();
+///   if (last_error != NULL) {
+///     printf("last error = %s\n", last_error);
+///     qrmi_string_free(last_error);
+///   }
+/// @endcode
 ///
 /// @return message text of the most recent error
 /// @version 0.8.0
@@ -493,8 +511,10 @@ pub unsafe extern "C" fn qrmi_get_last_error() -> *const c_char {
 ///
 /// # Example
 ///
-///     QrmiQuantumResource *qrmi = qrmi_resource_new("your_resource_name",
-///                                                   QRMI_RESOURCE_TYPE_IBM_DIRECT_ACCESS);
+/// @code
+///   QrmiQuantumResource *qrmi = qrmi_resource_new("your_resource_name",
+///                                                 QRMI_RESOURCE_TYPE_IBM_DIRECT_ACCESS);
+/// @endcode
 ///
 /// @param (resource_id) [in] A resource identifier, i.e. backend name
 /// @param (resource_type) [in] QrmiResourceType variant
@@ -549,11 +569,13 @@ pub unsafe extern "C" fn qrmi_resource_new(
 ///
 /// # Example
 ///
-///     QrmiQuantumResource *qrmi = qrmi_resource_new("your_resource_name",
-///                                                   QRMI_RESOURCE_TYPE_IBM_DIRECT_ACCESS);
-///     if (qrmi != NULL) {
-///         qrmi_resource_free(qrmi);
-///     }
+/// @code
+///   QrmiQuantumResource *qrmi = qrmi_resource_new("your_resource_name",
+///                                                 QRMI_RESOURCE_TYPE_IBM_DIRECT_ACCESS);
+///   if (qrmi != NULL) {
+///     qrmi_resource_free(qrmi);
+///   }
+/// @endcode
 ///
 /// @param (ptr) [in] A QrmiQuantumResource handle to be free
 /// @return @ref QrmiReturnCode::QRMI_RETURN_CODE_SUCCESS if succeeded.
@@ -581,15 +603,17 @@ pub unsafe extern "C" fn qrmi_resource_free(ptr: *mut QuantumResource) -> Return
 ///
 /// # Example
 ///
-///     bool is_accessible = false;
-///     int rc = qrmi_resource_is_accessible(qrmi, &is_accessible);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///        if (is_accessible == false) {
-///            printf("%s cannot be accessed.\n", argv[1]);
-///        }
-///     } else {
-///        printf("qrmi_resource_is_accessible() failed.\n");
+/// @code
+///   bool is_accessible = false;
+///   int rc = qrmi_resource_is_accessible(qrmi, &is_accessible);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     if (is_accessible == false) {
+///       printf("%s cannot be accessed.\n", argv[1]);
 ///     }
+///   } else {
+///     printf("qrmi_resource_is_accessible() failed.\n");
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (outp) [out] accessible or not
@@ -703,14 +727,16 @@ pub unsafe extern "C" fn qrmi_resource_type(
 ///
 /// # Example
 ///
-///     char *acquisition_token;
-///     QrmiReturnCode rc = qrmi_resource_acquire(qrmi, &acquisition_token);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///         printf("acquisition token = %s\n", acquisition_token);
-///     }
-///     else {
-///         printf("qrmi_resource_acquire failed.");
-///     }
+/// @code
+///   char *acquisition_token;
+///   QrmiReturnCode rc = qrmi_resource_acquire(qrmi, &acquisition_token);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     printf("acquisition token = %s\n", acquisition_token);
+///   }
+///   else {
+///     printf("qrmi_resource_acquire failed.");
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (acquisition_token) [out] An acquisition token if succeeded. Must call qrmi_string_free() to free if no longer used.
@@ -758,14 +784,16 @@ pub unsafe extern "C" fn qrmi_resource_acquire(
 ///
 /// # Example
 ///
-///     char *acquisition_token = NULL;
-///     QrmiReturnCode rc = qrmi_resource_acquire(qrmi, &acquisition_token);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///         rc = qrmi_resource_release(qrmi, acquisition_token);
-///         if (rc != QRMI_RETURN_CODE_SUCCESS) {
-///             printf("Failed to release a quantum resource\n");
-///         }
+/// @code
+///   char *acquisition_token = NULL;
+///   QrmiReturnCode rc = qrmi_resource_acquire(qrmi, &acquisition_token);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     rc = qrmi_resource_release(qrmi, acquisition_token);
+///     if (rc != QRMI_RETURN_CODE_SUCCESS) {
+///       printf("Failed to release a quantum resource\n");
 ///     }
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (acquisition_token) [in] An acquisition token returned by qrmi_resource_acquire() call.
@@ -813,21 +841,24 @@ pub unsafe extern "C" fn qrmi_resource_release(
 ///
 /// # Example
 ///
-///     QrmiPayload payload;
-///     char *job_id = NULL;
-///     QrmiReturnCode rc;
+/// @code
+///   QrmiPayload payload;
+///   char *job_id = NULL;
+///   QrmiReturnCode rc;
+///   const char* input = "your Qiskit estimator primitive input";
 ///
-///     payload.tag = QRMI_PAYLOAD_QISKIT_PRIMITIVE;
-///     payload.QISKIT_PRIMITIVE.input = (char *)input;
-///     payload.QISKIT_PRIMITIVE.program_id = "estimator";
+///   payload.tag = QRMI_PAYLOAD_QISKIT_PRIMITIVE;
+///   payload.QISKIT_PRIMITIVE.input = (char *)input;
+///   payload.QISKIT_PRIMITIVE.program_id = "estimator";
 ///
-///     rc = qrmi_resource_task_start(qrmi, &payload, &job_id);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///         printf("Job ID: %s\n", job_id);
-///     }
-///     else {
-///         printf("failed to start a task.\n");
-///     }
+///   rc = qrmi_resource_task_start(qrmi, &payload, &job_id);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     printf("Job ID: %s\n", job_id);
+///   }
+///   else {
+///     printf("failed to start a task.\n");
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (payload) [in] payload
@@ -900,10 +931,12 @@ pub unsafe extern "C" fn qrmi_resource_task_start(
 ///
 /// # Example
 ///
-///     QrmiReturnCode rc = qrmi_resource_task_stop(qrmi, job_id);
-///     if (rc != QRMI_RETURN_CODE_SUCCESS) {
-///         printf("Failed to stop a task\n");
-///     }
+/// @code
+///   QrmiReturnCode rc = qrmi_resource_task_stop(qrmi, job_id);
+///   if (rc != QRMI_RETURN_CODE_SUCCESS) {
+///     printf("Failed to stop a task\n");
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (task_id) [in] A task ID, returned by a previous call to qrmi_resource_task_start()
@@ -952,14 +985,16 @@ pub unsafe extern "C" fn qrmi_resource_task_stop(
 ///
 /// # Example
 ///
-///     QrmiTaskStatus status;
-///     while (1) {
-///         rc = qrmi_resource_task_status(qrmi, job_id, &status);
-///         if (rc != QRMI_RETURN_CODE_SUCCESS || status != QRMI_TASK_STATUS_RUNNING) {
-///             break;
-///         }
-///         sleep(1);
+/// @code
+///   QrmiTaskStatus status;
+///   while (1) {
+///     rc = qrmi_resource_task_status(qrmi, job_id, &status);
+///     if (rc != QRMI_RETURN_CODE_SUCCESS || status != QRMI_TASK_STATUS_RUNNING) {
+///       break;
 ///     }
+///     sleep(1);
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (task_id) [in] A task identifier
@@ -1012,13 +1047,15 @@ pub unsafe extern "C" fn qrmi_resource_task_status(
 ///
 /// # Example
 ///
-///     QrmiReturnCode rc = qrmi_resource_task_status(qrmi, job_id, &status);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS && status == QRMI_TASK_STATUS_COMPLETED) {
-///         char *result = NULL;
-///         qrmi_resource_task_result(qrmi, job_id, &result);
-///         printf("%s\n", result);
-///         qrmi_string_free((char *)result);
-///     }
+/// @code
+///   QrmiReturnCode rc = qrmi_resource_task_status(qrmi, job_id, &status);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS && status == QRMI_TASK_STATUS_COMPLETED) {
+///     char *result = NULL;
+///     qrmi_resource_task_result(qrmi, job_id, &result);
+///     printf("%s\n", result);
+///     qrmi_string_free((char *)result);
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (task_id) [in] A task identifier
@@ -1075,13 +1112,15 @@ pub unsafe extern "C" fn qrmi_resource_task_result(
 ///
 /// # Example
 ///
-///     QrmiReturnCode rc = qrmi_resource_task_status(qrmi, job_id, &status);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS && status == QRMI_TASK_STATUS_COMPLETED) {
-///         char *logs = NULL;
-///         qrmi_resource_task_logs(qrmi, job_id, &logs);
-///         printf("%s\n", logs);
-///         qrmi_string_free((char *)logs);
-///     }
+/// @code
+///   QrmiReturnCode rc = qrmi_resource_task_status(qrmi, job_id, &status);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS && status == QRMI_TASK_STATUS_COMPLETED) {
+///     char *logs = NULL;
+///     qrmi_resource_task_logs(qrmi, job_id, &logs);
+///     printf("%s\n", logs);
+///     qrmi_string_free((char *)logs);
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (task_id) [in] A task identifier
@@ -1134,13 +1173,15 @@ pub unsafe extern "C" fn qrmi_resource_task_logs(
 ///
 /// # Example
 ///
-///     char *target = NULL;
-///     QrmiReturnCode rc;
-///     rc = qrmi_resource_target(qrmi, &target);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///         printf("target = %s\n", target);
-///         qrmi_string_free(target);
-///     }
+/// @code
+///   char *target = NULL;
+///   QrmiReturnCode rc;
+///   rc = qrmi_resource_target(qrmi, &target);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     printf("target = %s\n", target);
+///     qrmi_string_free(target);
+///   }
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (outp) [out] A serialized target data if succeeded. Must call qrmi_string_free() to free if no longer used.
@@ -1186,8 +1227,10 @@ pub unsafe extern "C" fn qrmi_resource_target(
 ///
 /// # Example
 ///
-///     QrmiResourceMetadata *metadata = NULL;
-///     QrmiReturnCode rc = qrmi_resource_metadata(qrmi, &metadata);
+/// @code
+///   QrmiResourceMetadata *metadata = NULL;
+///   QrmiReturnCode rc = qrmi_resource_metadata(qrmi, &metadata);
+/// @endcode
 ///
 /// @param (qrmi) [in] A QrmiQuantumResource handle
 /// @param (outp) [out] A QrmiResourceMetadata handle. Must call qrmi_resource_metadata_free() to free if no longer used.
@@ -1222,11 +1265,13 @@ pub unsafe extern "C" fn qrmi_resource_metadata(
 ///
 /// # Example
 ///
-///     QrmiResourceMetadata *metadata = NULL;
-///     QrmiReturnCode rc = qrmi_resource_metadata(qrmi, &metadata);
-///     if (retval == QRMI_RETURN_CODE_SUCCESS) {
-///         qrmi_resource_metadata_free(metadata);
-///     }
+/// @code
+///   QrmiResourceMetadata *metadata = NULL;
+///   QrmiReturnCode rc = qrmi_resource_metadata(qrmi, &metadata);
+///   if (retval == QRMI_RETURN_CODE_SUCCESS) {
+///     qrmi_resource_metadata_free(metadata);
+///   }
+/// @endcode
 ///
 /// @param (ptr) [in] A QrmiResourceMetadata handle to be free
 /// @return @ref QrmiReturnCode::QRMI_RETURN_CODE_SUCCESS if succeeded.
@@ -1256,9 +1301,11 @@ pub unsafe extern "C" fn qrmi_resource_metadata_free(ptr: *mut ResourceMetadata)
 ///
 /// # Example
 ///
-///     char *value = qrmi_resource_metadata_value(metadata, "backend_name");
-///     printf("metadata value=[%s]\n", value);
-///     qrmi_string_free(value);
+/// @code
+///   char *value = qrmi_resource_metadata_value(metadata, "backend_name");
+///   printf("metadata value=[%s]\n", value);
+///   qrmi_string_free(value);
+/// @endcode
 ///
 /// @param (metadata) [in] A QrmiResourceMetadata handle
 /// @param (key) [in] metadata key name
@@ -1296,15 +1343,17 @@ pub unsafe extern "C" fn qrmi_resource_metadata_value(
 ///
 /// # Example
 ///
-///     size_t num_keys = 0;
-///     char **metadata_keys = NULL;
-///     QrmiReturnCode rc = qrmi_resource_metadata_keys(metadata, &num_keys, &metadata_keys);
-///     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-///         for (int i = 0; i < num_keys; i++) {
-///             printf("%s\n", metadata_keys[i]);
-///         }
-///         qrmi_string_array_free(num_keys, metadata_keys);
+/// @code
+///   size_t num_keys = 0;
+///   char **metadata_keys = NULL;
+///   QrmiReturnCode rc = qrmi_resource_metadata_keys(metadata, &num_keys, &metadata_keys);
+///   if (rc == QRMI_RETURN_CODE_SUCCESS) {
+///     for (int i = 0; i < num_keys; i++) {
+///       printf("%s\n", metadata_keys[i]);
 ///     }
+///     qrmi_string_array_free(num_keys, metadata_keys);
+///   }
+/// @endcode
 ///
 /// @param (metadata) [in] A QrmiResourceMetadata handle
 /// @param (num_keys) [out] number of keys available in the metadata

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///
     ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
     ///     let resource_id = qrmi.resource_id().await?;
     ///     println!("{resource_id}"); // prints "ibm_torino"
@@ -47,7 +50,10 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///
     ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
     ///     let resource_type = qrmi.resource_type().await?;
     ///     println!("{}", resource_type.as_str()); // prints "qiskit_runtime_service"
@@ -61,9 +67,11 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
-    ///     let token = qrmi.acquire().unwrap();
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let token = qrmi.acquire().await?;
     ///     println!("acquisition token = {}", token);
     ///     Ok(())
     /// }
@@ -75,8 +83,10 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
     ///     qrmi.release("your_acquisition_token").await?;
     ///     Ok(())
     /// }
@@ -92,12 +102,14 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     use std::fs::File;
     ///     use std::io::prelude::*;
     ///     use std::io::BufReader;
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
     ///
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
     ///
     ///     let f = File::open("sampler_input.json").expect("file not found");
     ///     let mut buf_reader = BufReader::new(f);
@@ -106,9 +118,9 @@ pub trait QuantumResource: Send + Sync {
     ///
     ///     let payload = qrmi::models::Payload::QiskitPrimitive {
     ///          input: contents,
-    ///          program_id: args.program_id,
+    ///          program_id: "sampler".to_string(),
     ///     };
-    ///     let job_id = qrmi.task_start(payload).unwrap();
+    ///     let job_id = qrmi.task_start(payload).await?;
     ///     println!("Job ID: {}", job_id);
     ///     Ok(())
     /// }
@@ -124,9 +136,12 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
-    ///     qrmi.task_stop("your_task_id").unwrap();
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     qrmi.task_stop("your_task_id").await?;
     ///     Ok(())
     /// }
     /// ```
@@ -141,11 +156,12 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{QiskitRuntimeService};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
     ///
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
-    ///     let status = qrmi.task_status("your_task_id").unwrap();
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let status = qrmi.task_status("your_task_id").await?;
     ///     println!("{:?}", status);
     ///     Ok(())
     /// }
@@ -161,11 +177,13 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{QiskitRuntimeService};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
     ///
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
-    ///     let result = qrmi.task_result(&job_id).unwrap();
+    ///     let job_id = "4EAAA9E2-AD53-4C5C-8EF1-C1A3F219C427";
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let result = qrmi.task_result(&job_id).await?;
     ///     println!("{:?}", result.value);
     ///     Ok(())
     /// }
@@ -181,11 +199,13 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{QiskitRuntimeService};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
     ///
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
-    ///     let log = qrmi.task_log(&job_id).unwrap();
+    ///     let job_id = "4EAAA9E2-AD53-4C5C-8EF1-C1A3F219C427";
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let log = qrmi.task_logs(&job_id).await?;
     ///     println!("{:?}", log);
     ///     Ok(())
     /// }
@@ -195,11 +215,12 @@ pub trait QuantumResource: Send + Sync {
     /// Returns a Target for the specified device. Vendor specific serialized data. This might contain the constraints(instructions, properteis and timing information etc.) of a particular device to allow compilers to compile an input circuit to something that works and is optimized for a device. In IBM implementation, it contains JSON representations of [BackendConfiguration](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json) and [BackendProperties](https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_properties_schema.json) so that we are able to create a Target object by calling `qiskit_ibm_runtime.utils.backend_converter.convert_to_target` or uquivalent functions.
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{QiskitRuntimeService};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
     ///
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
-    ///     let target = qrmi.target().unwrap();
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let target = qrmi.target().await?;
     ///     println!("{:?}", target.value);
     ///     Ok(())
     /// }
@@ -211,11 +232,12 @@ pub trait QuantumResource: Send + Sync {
     /// # Example
     ///
     /// ```no_run
-    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{QiskitRuntimeService};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
     ///
-    ///     let mut qrmi = qrmi::QiskitRuntimeService::new("ibm_torino");
-    ///     let metadata = qrmi.metadata();
+    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let metadata = qrmi.metadata().await;
     ///     println!("{:?}", metadata);
     ///     Ok(())
     /// }


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Fixed the errors reported by invoking `cargo test --doc --locked --release`.
No functional changes are introduced - Just updated comment block in Rust code.

Before applying this PR: [errors.txt](https://github.com/user-attachments/files/26172686/errors.txt)

After applying this PR:

```
running 11 tests
test src/lib.rs - QuantumResource::resource_type (line 35) - compile ... ok
test src/lib.rs - QuantumResource::is_accessible (line 52) - compile ... ok
test src/lib.rs - QuantumResource::acquire (line 69) - compile ... ok
test src/lib.rs - QuantumResource::task_logs (line 201) - compile ... ok
test src/lib.rs - QuantumResource::release (line 85) - compile ... ok
test src/lib.rs - QuantumResource::metadata (line 234) - compile ... ok
test src/lib.rs - QuantumResource::target (line 217) - compile ... ok
test src/lib.rs - QuantumResource::task_status (line 158) - compile ... ok
test src/lib.rs - QuantumResource::task_start (line 104) - compile ... ok
test src/lib.rs - QuantumResource::task_result (line 179) - compile ... ok
test src/lib.rs - QuantumResource::task_stop (line 138) - compile ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.38s
```

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [x] Fixes #87
- [ ] Is Part of #
