### PR TITLE
tarball-vendor: Build the tarball in a ubi8 container

### DIFF
--- a/.github/workflows/tarball-vendor.yml
+++ b/.github/workflows/tarball-vendor.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   vendor-tarball:
     runs-on: ubuntu-24.04
+    container:
+      image: 'registry.access.redhat.com/ubi8/ubi:8.10'
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
## Description of Change

All other workflows in the CI are running on ubi8. Let's do the same for the vendor-tarball, keep it consistent.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
