### PR TITLE
[FEATURE|PASQAL] Update pasqal local 'is_accessible' method to get data from pasqal middleware

### DIFF
--- a/dependencies/pasqal_local_client/src/client.rs
+++ b/dependencies/pasqal_local_client/src/client.rs
@@ -125,17 +125,11 @@ impl Client {
         self.handle_request(resp).await
     }
 
-    pub async fn get_accessible(
-        &self,
-    ) -> Result<AccessibleResponse> {
+    pub async fn get_accessible(&self) -> Result<AccessibleResponse> {
         let url = format!("{}/accessible", self.base_url);
 
-        let resp = self
-            .client
-            .get(url)
-            .send()
-            .await?;
-        
+        let resp = self.client.get(url).send().await?;
+
         self.handle_request(resp).await
     }
 

--- a/dependencies/pasqal_local_client/src/client.rs
+++ b/dependencies/pasqal_local_client/src/client.rs
@@ -46,6 +46,12 @@ pub struct CreateJob {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct AccessibleResponse {
+    pub is_accessible: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct SessionResponse {
     pub id: String,
 }
@@ -116,6 +122,20 @@ impl Client {
             .send()
             .await?;
 
+        self.handle_request(resp).await
+    }
+
+    pub async fn get_accessible(
+        &self,
+    ) -> Result<AccessibleResponse> {
+        let url = format!("{}/accessible", self.base_url);
+
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await?;
+        
         self.handle_request(resp).await
     }
 

--- a/src/pasqal/local.rs
+++ b/src/pasqal/local.rs
@@ -68,14 +68,8 @@ impl QuantumResource for PasqalLocal {
     }
 
     async fn is_accessible(&mut self) -> Result<bool> {
-        match self
-            .api_client
-            .get_accessible()
-            .await
-        {
-            Ok(accessible) => {
-                Ok(accessible.is_accessible)
-            }
+        match self.api_client.get_accessible().await {
+            Ok(accessible) => Ok(accessible.is_accessible),
             Err(err) => Err(err),
         }
     }

--- a/src/pasqal/local.rs
+++ b/src/pasqal/local.rs
@@ -68,8 +68,16 @@ impl QuantumResource for PasqalLocal {
     }
 
     async fn is_accessible(&mut self) -> Result<bool> {
-        //TODO: Define when this should return false
-        Ok(true)
+        match self
+            .api_client
+            .get_accessible()
+            .await
+        {
+            Ok(accessible) => {
+                Ok(accessible.is_accessible)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     async fn acquire(&mut self) -> Result<String> {


### PR DESCRIPTION
## Description of Change

Instead of always returning "Ok(true)" for the `is_accessible` interface in Pasqal local qrmi implementation, we delegate the information to the pasqal local middleware "Warden" [at this endpoint](https://github.com/pasqal-io/warden/blob/d1ae4ea6e1e99a9dba293685c9c9fceaf973b285/warden/api/routes/accessible.py#L12). 

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
