### PR TITLE
CI release: Remove job that publish to test.pypi.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
   publish-github:
     if: github.repository_owner == 'qiskit-community'
     name: Publish github release
-    needs: [valid-qrmi-version, create-draft-release, check-testpypi-release]
+    needs: [valid-qrmi-version, create-draft-release]
     permissions:
       contents: write # This is required to publish the draft release
     runs-on: ubuntu-24.04
@@ -152,13 +152,13 @@ jobs:
         if-no-files-found: error
         retention-days: 1
 
-  publish-testpypi:
+  publish-pypi:
     if: github.repository_owner == 'qiskit-community'
-    needs: [build-and-test-wheels, wheels-sdist]
-    runs-on: ubuntu-24.04
+    needs: [build-and-test-wheels, wheels-sdist, publish-github]
+    runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/project/qrmi/
+      name: pypi
+      url: https://pypi.org/project/qrmi
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
@@ -170,13 +170,16 @@ jobs:
     - name: Publish QRMI wheels
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
         verbose: true
         print-hash: true
 
-  check-testpypi-release:
+  # Once a package version is released to either pypi.org or test.pypi.org,
+  # it cannot be overwritten or deleted/reused. This job checks if the
+  # version released to pypi can be installed and downloaded correctly.
+  # That could help to catch and address issues early.
+  check-pypi-post-release:
     if: github.repository_owner == 'qiskit-community'
-    needs: [publish-testpypi, valid-qrmi-version]
+    needs: [publish-pypi, valid-qrmi-version]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v6
@@ -187,26 +190,5 @@ jobs:
         python3.12 -m venv .venv_py312
         source .venv_py312/bin/activate
         pip install --upgrade pip
-        pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ qrmi==${{ needs.valid-qrmi-version.outputs.version }}
-        pip download --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ qrmi==${{ needs.valid-qrmi-version.outputs.version }} --no-binary qrmi --no-deps
-
-  publish-pypi:
-    if: github.repository_owner == 'qiskit-community'
-    needs: [build-and-test-wheels, wheels-sdist, check-testpypi-release, publish-github]
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/qrmi
-    permissions:
-      id-token: write  # IMPORTANN: this permission is mandatory for trusted publishing
-    steps:
-    - uses: actions/download-artifact@v8
-      with:
-        pattern: release-wheels-*
-        merge-multiple: true
-        path: dist/
-    - name: Publish QRMI wheels
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        verbose: true
-        print-hash: true
+        pip install qrmi==${{ needs.valid-qrmi-version.outputs.version }}
+        pip download qrmi==${{ needs.valid-qrmi-version.outputs.version }} --no-binary qrmi --no-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
   workflow_dispatch:
   
 jobs:
+
+  # Check if the current QRMI version has already been released.
+  # It also provides the checked QRMI version to other jobs through
+  # the needs field.
   valid-qrmi-version:
     if: github.repository_owner == 'qiskit-community'
     name: Check new QRMI version is valid
@@ -47,6 +51,7 @@ jobs:
   create-libqrmi-tarball-rhel:
     if: github.repository_owner == 'qiskit-community'
     name: Create libqrmi tarball for RHEL compatible distributions
+    needs: [valid-qrmi-version]
     uses: ./.github/workflows/tarball-libqrmi-el8.yml
       
   create-draft-release:
@@ -108,6 +113,7 @@ jobs:
 
   build-and-test-wheels:
     if: github.repository_owner == 'qiskit-community'
+    needs: [valid-qrmi-version]
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
@@ -133,6 +139,7 @@ jobs:
 
   wheels-sdist:
     if: github.repository_owner == 'qiskit-community'
+    needs: [valid-qrmi-version]
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6

--- a/Makefile_common.mk
+++ b/Makefile_common.mk
@@ -20,7 +20,8 @@ MAKEFLAGS += --no-print-directory
 get-qrmi-version:
 	@echo "$(QRMI_VERSION)"
 
-# Before releasing a new qrmi version, we check if the current version was not released yet
+# Before releasing a new qrmi version, we check if the current version
+# was not released yet in github and pypi.
 check-new-qrmi-version-valid:
 	@NEW_QRMI_VERSION=$$($(MAKE) get-qrmi-version); \
 	if [ -z "$${NEW_QRMI_VERSION}" ]; then \
@@ -34,6 +35,11 @@ check-new-qrmi-version-valid:
 		exit 1; \
 	elif [ "$${HTTP_CODE}" != "404" ]; then \
 		echo "Error: Failed to check GitHub releases (HTTP $${HTTP_CODE})"; \
+		exit 1; \
+	fi; \
+	if curl -s https://pypi.org/pypi/qrmi/json | jq -r '.releases | keys[]' | grep -q "$${NEW_QRMI_VERSION}"; then \
+		echo "Error: Release v$${NEW_QRMI_VERSION} already exists in PyPI"; \
+		echo "Please update the version in Cargo.toml and try again"; \
 		exit 1; \
 	fi; \
 	echo "New QRMI version v$${NEW_QRMI_VERSION} is valid"


### PR DESCRIPTION
## Description of Change

Once a package version is published to either pypi.org or test.pypi.org,
it cannot be overwritten or deleted/reused. So, it does not make sense
to publish to test.pypi.org in a workflow also used to publish to
pypi.org. If the job fails while publishing to test.pypi.org, we  would
need to bump the qrmi version to run the workflow again, however,
ultimately those versions would never exist in the actual pypi.org.

This PR removes the job that publishes to test.pypi.org, but adds a job
to check if the version published to pypi.org can be installed and
downloaded correctly. That could help catching and addressing issues
early in the version just published.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [x] Fixes #108 
- [ ] Is Part of #
