### PR TITLE
Detect-secrets CI enforcement through Github Action

### DIFF
--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -1,0 +1,66 @@
+---
+name: 'detect-secrets'
+description: 'Scans your GitHub repository for accidentally committed secrets, enhances code security, and help cleanup the secrets'
+  
+# This is our CI enforcement method (Remediation, not the prevention) 
+# secret commit is prevented using pre-commit methods as described in README.md
+# This method detect/remediate any secrets mistakenly coming into our repo
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Manual testing of this workflow'
+        required: false
+        default: 'Manual testing'
+      
+jobs:
+  secret-detection:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # Install detect-secrets. latest version is 1.5.0. 2026 April
+      - name: Install detect secret pacakge
+        run: |
+          pip install "detect-secrets==1.5.0"
+          # package for JSON operations.
+          pip install jq
+
+      # In case .secret.baseline file does not exist, code still has to run by 
+      # generating empty baseline
+      - name: Sanity check .secrets.baseline file
+        run: |
+          if [ ! -f .secrets.baseline ]; then
+            echo "No.secrets.baseline detected. Creating a new blank baseline file."
+            mkdir empty-dir
+            detect-secrets scan empty-dir > .secrets.baseline
+            echo "Blank .secrets.baseline file created successfully."
+            rm -r empty-dir
+          else
+            echo ".secrets.baseline detected."
+          fi
+
+      # Scan entire repository for detecting secrets
+      - name: Scan repository
+        run: |
+          # save the list of known secrets
+          cp .secrets.baseline .secrets.new
+
+          # find the secrets in the repository
+          detect-secrets scan --force-use-all-plugins --exclude-files '.secrets.*' --exclude-files '.git*' --baseline .secrets.new     
+
+          # Function to compare secrets without listing them
+          compare_secrets() { diff <(jq -r '.results | keys[] as $key | "\($key),\(.[$key] | .[] | .hashed_secret)"' "$1" | sort) <(jq -r '.results | keys[] as $key | "\($key),\(.[$key] | .[] | .hashed_secret)"' "$2" | sort) >/dev/null; }
+        
+          # Check if there's any difference between the baseline and new detected secrets 
+          if ! compare_secrets .secrets.baseline .secrets.new; then
+            echo "New secrets have been detected in your recent commit. Due to security concerns, we cannot display detailed information here and we cannot proceed until this issue is resolved." >&2
+            echo "" >&2
+            echo "Run the 'detect-secrets scan' tool on your local machine. This tool will identify and clean up the secrets. You can find detailed instructions at this link: https://github.com/eklee15/qrmi-forked/tree/main" >&2
+            echo "" >&2
+            echo "After cleaning up the secrets, commit your changes and re-push your update to the repository." >&2
+            exit 1
+          fi

--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -59,7 +59,7 @@ jobs:
           if ! compare_secrets .secrets.baseline .secrets.new; then
             echo "New secrets have been detected in your recent commit. Due to security concerns, we cannot display detailed information here and we cannot proceed until this issue is resolved." >&2
             echo "" >&2
-            echo "Run the 'detect-secrets scan' tool on your local machine. This tool will identify and clean up the secrets. You can find detailed instructions at this link: https://github.com/eklee15/qrmi-forked/tree/main" >&2
+            echo "Run the 'detect-secrets scan' tool on your local machine. This tool will identify and clean up the secrets. You can find detailed instructions at this link: https://github.com/qiskit-community/qrmi/tree/main?tab=readme-ov-file#pre-commit-detect-secrets" >&2
             echo "" >&2
             echo "After cleaning up the secrets, commit your changes and re-push your update to the repository." >&2
             exit 1

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,20 +127,20 @@
     }
   ],
   "results": {
-    "dependencies/direct_access_client/README.md": [
+    "dependencies/quantum_system_client/README.md": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/README.md",
+        "filename": "dependencies/quantum_system_client/README.md",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 114,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/app/backend/src/main.rs": [
+    "dependencies/quantum_system_client/app/backend/src/main.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/backend/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/backend/src/main.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 32,
@@ -148,17 +148,17 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/backend/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/backend/src/main.rs",
         "hashed_secret": "f15426859be5cc9f08f2a41804deed42176398cd",
         "is_verified": false,
         "line_number": 38,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/app/cancel_job/src/main.rs": [
+    "dependencies/quantum_system_client/app/cancel_job/src/main.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/cancel_job/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/cancel_job/src/main.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 47,
@@ -166,17 +166,17 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/cancel_job/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/cancel_job/src/main.rs",
         "hashed_secret": "f15426859be5cc9f08f2a41804deed42176398cd",
         "is_verified": false,
         "line_number": 53,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/app/delete_job/src/main.rs": [
+    "dependencies/quantum_system_client/app/delete_job/src/main.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/delete_job/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/delete_job/src/main.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 43,
@@ -184,17 +184,17 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/delete_job/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/delete_job/src/main.rs",
         "hashed_secret": "f15426859be5cc9f08f2a41804deed42176398cd",
         "is_verified": false,
         "line_number": 49,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/app/job_details/src/main.rs": [
+    "dependencies/quantum_system_client/app/job_details/src/main.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/job_details/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/job_details/src/main.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 44,
@@ -202,17 +202,17 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/job_details/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/job_details/src/main.rs",
         "hashed_secret": "f15426859be5cc9f08f2a41804deed42176398cd",
         "is_verified": false,
         "line_number": 50,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/app/list_jobs/src/main.rs": [
+    "dependencies/quantum_system_client/app/list_jobs/src/main.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/list_jobs/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/list_jobs/src/main.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 31,
@@ -220,17 +220,17 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/list_jobs/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/list_jobs/src/main.rs",
         "hashed_secret": "f15426859be5cc9f08f2a41804deed42176398cd",
         "is_verified": false,
         "line_number": 37,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/app/run_job/src/main.rs": [
+    "dependencies/quantum_system_client/app/run_job/src/main.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/run_job/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/run_job/src/main.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 71,
@@ -238,17 +238,17 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/run_job/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/run_job/src/main.rs",
         "hashed_secret": "f15426859be5cc9f08f2a41804deed42176398cd",
         "is_verified": false,
         "line_number": 77,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/app/run_primitive/src/main.rs": [
+    "dependencies/quantum_system_client/app/run_primitive/src/main.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/run_primitive/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/run_primitive/src/main.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 59,
@@ -256,177 +256,177 @@
       },
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/app/run_primitive/src/main.rs",
+        "filename": "dependencies/quantum_system_client/app/run_primitive/src/main.rs",
         "hashed_secret": "f15426859be5cc9f08f2a41804deed42176398cd",
         "is_verified": false,
         "line_number": 65,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/backend_config.rs": [
+    "dependencies/quantum_system_client/src/api/backend_config.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/backend_config.rs",
+        "filename": "dependencies/quantum_system_client/src/api/backend_config.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 29,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/backend_details.rs": [
+    "dependencies/quantum_system_client/src/api/backend_details.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/backend_details.rs",
+        "filename": "dependencies/quantum_system_client/src/api/backend_details.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 28,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/backend_props.rs": [
+    "dependencies/quantum_system_client/src/api/backend_props.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/backend_props.rs",
+        "filename": "dependencies/quantum_system_client/src/api/backend_props.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 28,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/backend_pulse_defaults.rs": [
+    "dependencies/quantum_system_client/src/api/backend_pulse_defaults.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/backend_pulse_defaults.rs",
+        "filename": "dependencies/quantum_system_client/src/api/backend_pulse_defaults.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 29,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/cancel_job.rs": [
+    "dependencies/quantum_system_client/src/api/cancel_job.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/cancel_job.rs",
+        "filename": "dependencies/quantum_system_client/src/api/cancel_job.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 31,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/delete_job.rs": [
+    "dependencies/quantum_system_client/src/api/delete_job.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/delete_job.rs",
+        "filename": "dependencies/quantum_system_client/src/api/delete_job.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 30,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/job_details.rs": [
+    "dependencies/quantum_system_client/src/api/job_details.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/job_details.rs",
+        "filename": "dependencies/quantum_system_client/src/api/job_details.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 28,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/job_status.rs": [
+    "dependencies/quantum_system_client/src/api/job_status.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/job_status.rs",
+        "filename": "dependencies/quantum_system_client/src/api/job_status.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 28,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/job_wait_for_final_state.rs": [
+    "dependencies/quantum_system_client/src/api/job_wait_for_final_state.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/job_wait_for_final_state.rs",
+        "filename": "dependencies/quantum_system_client/src/api/job_wait_for_final_state.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 32,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/list_backends.rs": [
+    "dependencies/quantum_system_client/src/api/list_backends.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/list_backends.rs",
+        "filename": "dependencies/quantum_system_client/src/api/list_backends.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 28,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/list_jobs.rs": [
+    "dependencies/quantum_system_client/src/api/list_jobs.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/list_jobs.rs",
+        "filename": "dependencies/quantum_system_client/src/api/list_jobs.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 28,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/run_job.rs": [
+    "dependencies/quantum_system_client/src/api/run_job.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/run_job.rs",
+        "filename": "dependencies/quantum_system_client/src/api/run_job.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 53,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/api/run_primitive.rs": [
+    "dependencies/quantum_system_client/src/api/run_primitive.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/api/run_primitive.rs",
+        "filename": "dependencies/quantum_system_client/src/api/run_primitive.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 51,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/client.rs": [
+    "dependencies/quantum_system_client/src/client.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/client.rs",
+        "filename": "dependencies/quantum_system_client/src/client.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 270,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/models/backend_configuration.rs": [
+    "dependencies/quantum_system_client/src/models/backend_configuration.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/models/backend_configuration.rs",
+        "filename": "dependencies/quantum_system_client/src/models/backend_configuration.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 95,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/src/models/backend_properties.rs": [
+    "dependencies/quantum_system_client/src/models/backend_properties.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/src/models/backend_properties.rs",
+        "filename": "dependencies/quantum_system_client/src/models/backend_properties.rs",
         "hashed_secret": "99d2c91e4b0918109da4e4f226abdc3390f7b606",
         "is_verified": false,
         "line_number": 52,
         "is_secret": false
       }
     ],
-    "dependencies/direct_access_client/tests/versions.rs": [
+    "dependencies/quantum_system_client/tests/versions.rs": [
       {
         "type": "Secret Keyword",
-        "filename": "dependencies/direct_access_client/tests/versions.rs",
+        "filename": "dependencies/quantum_system_client/tests/versions.rs",
         "hashed_secret": "0068d90bd2888c9985beebedae95ebc166833b25",
         "is_verified": false,
         "line_number": 61,
@@ -444,5 +444,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-25T20:41:30Z"
+  "generated_at": "2026-04-15T19:00:40Z"
 }

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ update the baseline file. Once updated, include the modified .secrets.baseline
 in your Pull Request to ensure the pre-commit passes in the future.
 ```
 pip install detect-secrets
-detect-secrets scan --baseline .secrets.baseline
+detect-secrets scan --force-use-all-plugins --exclude-files '.secrets.*' --exclude-files '.git*' --baseline .secrets.baseline
 detect-secrets audit .secrets.baseline
 ```
 **Manual Execution and Overrides**  


### PR DESCRIPTION
## Introduction
As pre-commit detect-secret is optional, we would like to have a second-line defense of detect-secret CI pipeline with Github action as discussed in https://github.com/qiskit-community/qrmi/pull/89#issuecomment-4134191263.

Related Issue
https://github.com/qiskit-community/qrmi/issues/111

## Implementation Details
Logic behind this code is to find all the `hashed_secret` for the newly pushed code and compare it with the ones with the existing codes, and see if they are same or not. If they are different, we do not pass the test. 

## Background
`detect-secrets` tracks secrets using this `hashed_secret` without storing the actual and sensitive secret in plain text. The .secrets.baseline file includes hashed_secrets and it is the specific key used in this JSON file.

<!-- Please include a readable description about the change. -->

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
