### PR TITLE
CI: Update actions with old Node.js

### DIFF
--- a/.github/workflows/build-libqrmi.yml
+++ b/.github/workflows/build-libqrmi.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Upload artifacts to help developers with testing/debugging in their local environment
     - name: Upload libqrmi qrmi.h and librqmi.so
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: ${{ success() }}
       with:
         name: libqrmi-artifacts

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -57,7 +57,7 @@ jobs:
       run: maturin build --release
 
     - name: Upload QRMI wheels
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: ${{ success() }}
       with:
         name: qrmi-wheels

--- a/.github/workflows/lint-fmt-python.yml
+++ b/.github/workflows/lint-fmt-python.yml
@@ -38,7 +38,7 @@ jobs:
       run: xargs dnf install -y < requirements-distro.txt
 
     - name: Download QRMI wheels
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: qrmi-wheels
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.qrmi-info.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Ubuntu runner already comes with the package make installed
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create draft release
         env:
@@ -72,7 +72,7 @@ jobs:
           gh release create --draft --generate-notes --title "QRMI v${{ needs.valid-qrmi-version.outputs.version }}" "v${{ needs.valid-qrmi-version.outputs.version }}"
   
       - name: Download vendor tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: qrmi-vendor-tarball
 
@@ -83,7 +83,7 @@ jobs:
           gh release upload "v${{ needs.valid-qrmi-version.outputs.version }}" qrmi-${{ needs.valid-qrmi-version.outputs.version }}-vendor.tar.gz --clobber
 
       - name: Download libqrmi tarball for RHEL compatible distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: libqrmi-${{ needs.valid-qrmi-version.outputs.version }}-el8-x86_64-tarball
 
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Publish release
       env:
@@ -129,7 +129,7 @@ jobs:
         CIBW_PLATFORM: linux
         CIBW_BUILD: cp312-manylinux_x86_64
     - name: Upload QRMI wheels
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: ${{ success() }}
       with:
         name: release-wheels-x86_64

--- a/.github/workflows/tarball-libqrmi-el8.yml
+++ b/.github/workflows/tarball-libqrmi-el8.yml
@@ -25,7 +25,7 @@ jobs:
       image: registry.access.redhat.com/ubi8/ubi:8.10
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install package dependencies from distro
       run: xargs dnf install -y < requirements-distro.txt
@@ -45,7 +45,7 @@ jobs:
         echo "QRMI version: $VERSION"
 
     - name: Upload libqrmi tarball
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ success() }}
       with:
         name: libqrmi-${{ steps.qrmi-version.outputs.value }}-el8-x86_64-tarball

--- a/.github/workflows/tarball-vendor.yml
+++ b/.github/workflows/tarball-vendor.yml
@@ -24,7 +24,7 @@ jobs:
       image: 'registry.access.redhat.com/ubi8/ubi:8.10'
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install package dependencies from distro
       run: xargs dnf install -y < requirements-distro.txt
@@ -43,7 +43,7 @@ jobs:
       run: make tarball-vendor
 
     - name: Upload vendor tarball
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: qrmi-vendor-tarball
         path: qrmi-${{ steps.qrmi-info.outputs.version }}-vendor.tar.gz

--- a/.github/workflows/unittest-python.yml
+++ b/.github/workflows/unittest-python.yml
@@ -38,7 +38,7 @@ jobs:
       run: xargs dnf install -y < requirements-distro.txt
 
     - name: Download QRMI wheels
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: qrmi-wheels
 


### PR DESCRIPTION
## Description of Change

Fixes #92

Updated the following github actions:
- download-artifact to v8
- upload-artifact to v7
- checkout to v6

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [x] Fixes #92
- [ ] Is Part of #
