### PR TITLE
Enable release wheel builds on aarch64 and ppc64le

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,13 @@ jobs:
   build-and-test-wheels:
     if: github.repository_owner == 'qiskit-community'
     needs: [valid-qrmi-version]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
@@ -132,7 +138,37 @@ jobs:
       uses: actions/upload-artifact@v7
       if: ${{ success() }}
       with:
-        name: release-wheels-x86_64
+        name: release-wheels-${{ matrix.os }}
+        path: ./wheelhouse/*.whl
+        if-no-files-found: error
+        retention-days: 1
+  crossbuild-ppc64_wheels:
+    if: github.repository_owner == 'qiskit-community'
+    needs: [valid-qrmi-version]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: 3.12
+    - uses: docker/setup-qemu-action@v4
+      with:
+        platforms: all
+    # The manylinux image comes with various cpython versions installed.
+    # We use the cpython 3.12 to build the wheels, as defined in the CIBW_BUILD.
+    # The generated wheels is abi3 compatible, so it is compatible with other python versions.
+    - name: Build QRMI wheels
+      uses: pypa/cibuildwheel@v3.4.1
+      env:
+        CIBW_PLATFORM: linux
+        CIBW_BUILD: cp312-manylinux_ppc64le
+        CIBW_ARCHS_LINUX: ppc64le
+        CIBW_TEST_SKIP: "cp*"
+    - name: Upload QRMI wheels
+      uses: actions/upload-artifact@v7
+      if: ${{ success() }}
+      with:
+        name: release-wheels-ppc64le
         path: ./wheelhouse/*.whl
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,54 +121,19 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-24.04-arm
+          - ubuntu-24.04-ppc64le
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: 3.12
-    # The manylinux image comes with various cpython versions installed.
-    # We use the cpython 3.12 to build the wheels, as defined in the CIBW_BUILD.
-    # The generated wheels is abi3 compatible, so it is compatible with other python versions.
     - name: Build QRMI wheels
       uses: pypa/cibuildwheel@v3.4.1
-      env:
-        CIBW_PLATFORM: linux
-        CIBW_BUILD: cp312-manylinux_x86_64
     - name: Upload QRMI wheels
       uses: actions/upload-artifact@v7
       if: ${{ success() }}
       with:
         name: release-wheels-${{ matrix.os }}
-        path: ./wheelhouse/*.whl
-        if-no-files-found: error
-        retention-days: 1
-  crossbuild-ppc64_wheels:
-    if: github.repository_owner == 'qiskit-community'
-    needs: [valid-qrmi-version]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-      with:
-        python-version: 3.12
-    - uses: docker/setup-qemu-action@v4
-      with:
-        platforms: all
-    # The manylinux image comes with various cpython versions installed.
-    # We use the cpython 3.12 to build the wheels, as defined in the CIBW_BUILD.
-    # The generated wheels is abi3 compatible, so it is compatible with other python versions.
-    - name: Build QRMI wheels
-      uses: pypa/cibuildwheel@v3.4.1
-      env:
-        CIBW_PLATFORM: linux
-        CIBW_BUILD: cp312-manylinux_ppc64le
-        CIBW_ARCHS_LINUX: ppc64le
-        CIBW_TEST_SKIP: "cp*"
-    - name: Upload QRMI wheels
-      uses: actions/upload-artifact@v7
-      if: ${{ success() }}
-      with:
-        name: release-wheels-ppc64le
         path: ./wheelhouse/*.whl
         if-no-files-found: error
         retention-days: 1


### PR DESCRIPTION
## Description of Change

This commit adds two new jobs to the wheels release job that will build precompiled packages of linux for aarch64 and ppc64le platforms. Both CPU architectures have some presence in HPC systems and providing packages for those clusters will provide benefits to users leveraging quantum computing from those architectures. The arm builds run on github's arm hosted runners and are able to run tests and and the whole cibuildwheel workflow. For ppc64le however github doesn't have a hosted runner solution available for it. To build those wheels we run the manylinux docker image under qemu emulation of the platform. This is exceedingly slow in practice so we limit that wheel job to just compilation and building the wheel. This will skip running the tests which is unavoidable as it could take longer than the job timeout (6 hours) to run the full test suite under emulation.

## Checklist ✅

- [X] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [X] Fixes #116
- [ ] Is Part of #
