### PR TITLE
Make vendor specific dependencies optional

### DIFF
--- a/.github/workflows/lint-fmt-python.yml
+++ b/.github/workflows/lint-fmt-python.yml
@@ -59,7 +59,7 @@ jobs:
       run: pip install -r requirements-dev.txt
 
     - name: Install QRMI wheels
-      run: pip install qrmi-*.whl
+      run: pip install "$(ls qrmi-*.whl)[all]"
 
     - name: Format check with black
       run: black --check ./python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
       env:
         CIBW_PLATFORM: linux
         CIBW_BUILD: cp312-manylinux_x86_64
+        CIBW_TEST_EXTRAS: all
     - name: Upload QRMI wheels
       uses: actions/upload-artifact@v7
       if: ${{ success() }}

--- a/.github/workflows/unittest-python.yml
+++ b/.github/workflows/unittest-python.yml
@@ -56,7 +56,7 @@ jobs:
       run: pip install -r requirements-dev.txt
 
     - name: Install QRMI wheels
-      run: pip install 'qrmi-*.whl[all]'
+      run: pip install "$(ls qrmi-*.whl)[all]"
 
     - name: Unittest with pytest
       run: pytest -v ./python

--- a/.github/workflows/unittest-python.yml
+++ b/.github/workflows/unittest-python.yml
@@ -56,7 +56,7 @@ jobs:
       run: pip install -r requirements-dev.txt
 
     - name: Install QRMI wheels
-      run: pip install qrmi-*.whl
+      run: pip install 'qrmi-*.whl[all]'
 
     - name: Unittest with pytest
       run: pytest -v ./python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,21 @@ keywords = [
     "rust",
 ]
 dependencies = [
-  "qiskit_ibm_runtime>=0.30.0",
-  "qiskit_qasm3_import",
-  "qiskit-pasqal-provider>=0.1.1",
-  "pulser>=1.5.3",
   "python-dotenv",
   "python-dateutil",
 ]
+
+[project.optional-dependencies]
+ibm = [
+  "qiskit_ibm_runtime>=0.30.0",
+  "qiskit_qasm3_import",
+]
+pasqal = [
+  "qiskit-pasqal-provider>=0.1.1",
+  "pulser>=1.5.3",
+]
+all = ["qrmi[ibm,pasqal]"]
+
 [project.urls]
 repository = "https://github.com/qiskit-community/qrmi"
 


### PR DESCRIPTION


## Description of Change

Most QRMI installations do not require all the vendor plugins at once. Typically an installation will only have access to a quantum system from one or two vendors. Even if they have more it won't be all of the QRMI plugins at once. Requiring that a user that has a pasqal system install all of IBM's dependencies or vice versa complicates the install by making the Python dependency for QRMI much larger than what is needed for an installation. This commit splits out the vendor specific dependencies as optional dependency groups on the python package. So a user with an IBM quantum system installs `qrmi[ibm]` a user with IBM and Pasqal can install `qrmi[ibm,pasqal]`. When other vendors are added in the future they can be handled in this way. There is also an `all` optional added so if the user pip installs `qrmi[all]` it will install all the vendor dependencies.

One option that this commit does not implement is add a more graceful exception type around the vendor plugin code (you can look at what Qiskit does with it's `MissingOptionalLibrary` class and the optionals module with decorators as a model) to give a better UX when a vendor plugin is used and the dependencies are not installed. For right now it will just be an ImportError when the vendor specific module is used and one of the now optional libraries can't be found.

## Checklist ✅

- [X] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
