### PR TITLE
[PASQAL] Update PasqalLocal `task_logs` interface for request to Warden middleware

### DIFF
--- a/dependencies/pasqal_local_client/src/client.rs
+++ b/dependencies/pasqal_local_client/src/client.rs
@@ -61,6 +61,11 @@ pub struct GetDeviceSpecsResponse {
     pub specs: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetTaskLogsResponse {
+    pub logs: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateSessionPayload {
     pub user_id: String,
@@ -168,6 +173,12 @@ impl Client {
     pub async fn get_device_specs(&mut self) -> Result<GetDeviceSpecsResponse> {
         let url = format!("{}/qpu/specs", self.base_url);
         let resp: GetDeviceSpecsResponse = self.get(&url).await?;
+        Ok(resp)
+    }
+
+    pub async fn get_task_logs(&mut self, task_id: &str) -> Result<GetTaskLogsResponse> {
+        let url = format!("{}/jobs/{}/logs", self.base_url, task_id);
+        let resp: GetTaskLogsResponse = self.get(&url).await?;
         Ok(resp)
     }
 

--- a/python/qrmi/pulser_backend/backend.py
+++ b/python/qrmi/pulser_backend/backend.py
@@ -144,13 +144,13 @@ class PulserQRMIConnection(RemoteConnection):
             try:
                 logs = self._qrmi.task_logs(new_task_id)
                 print(f"Task logs: \n---\n{logs}---")
-            except RuntimeError as e:
-                if "404" in repr(e):
+            except RuntimeError as err:
+                if "404" in repr(err):
                     print(
                         "Task logs: Your Warden version doesn't support task_logs yet"
                     )
                 else:
-                    raise e
+                    raise err
         return results
 
 

--- a/python/qrmi/pulser_backend/backend.py
+++ b/python/qrmi/pulser_backend/backend.py
@@ -141,7 +141,14 @@ class PulserQRMIConnection(RemoteConnection):
                     break
                 print(f"Task status {status}, waiting 1s", flush=True)
                 time.sleep(1)
-            print(f"Task logs: \n---\n{self._qrmi.task_logs(new_task_id)}---")
+            try:
+                logs = self._qrmi.task_logs(new_task_id)
+                print(f"Task logs: \n---\n{logs}---")
+            except RuntimeError as e:
+                if "404" in repr(e):
+                    print(f"Task logs: Your Warden version doesn't support task_logs yet")
+                else:
+                    raise e
         return results
 
 

--- a/python/qrmi/pulser_backend/backend.py
+++ b/python/qrmi/pulser_backend/backend.py
@@ -146,7 +146,9 @@ class PulserQRMIConnection(RemoteConnection):
                 print(f"Task logs: \n---\n{logs}---")
             except RuntimeError as e:
                 if "404" in repr(e):
-                    print(f"Task logs: Your Warden version doesn't support task_logs yet")
+                    print(
+                        "Task logs: Your Warden version doesn't support task_logs yet"
+                    )
                 else:
                     raise e
         return results

--- a/python/qrmi/pulser_backend/backend.py
+++ b/python/qrmi/pulser_backend/backend.py
@@ -141,6 +141,7 @@ class PulserQRMIConnection(RemoteConnection):
                     break
                 print(f"Task status {status}, waiting 1s", flush=True)
                 time.sleep(1)
+            print(f"task logs: \n---\n{self._qrmi.task_logs(new_task_id)}\n---")
         return results
 
 

--- a/python/qrmi/pulser_backend/backend.py
+++ b/python/qrmi/pulser_backend/backend.py
@@ -141,7 +141,7 @@ class PulserQRMIConnection(RemoteConnection):
                     break
                 print(f"Task status {status}, waiting 1s", flush=True)
                 time.sleep(1)
-            print(f"task logs: \n---\n{self._qrmi.task_logs(new_task_id)}\n---")
+            print(f"Task logs: \n---\n{self._qrmi.task_logs(new_task_id)}---")
         return results
 
 

--- a/src/pasqal/local.rs
+++ b/src/pasqal/local.rs
@@ -148,9 +148,7 @@ impl QuantumResource for PasqalLocal {
 
     async fn task_logs(&mut self, task_id: &str) -> Result<String> {
         match self.api_client.get_task_logs(task_id).await {
-            Ok(resp) => {
-                Ok(resp.logs)
-            }
+            Ok(resp) => Ok(resp.logs),
             Err(err) => Err(err),
         }
     }

--- a/src/pasqal/local.rs
+++ b/src/pasqal/local.rs
@@ -146,8 +146,13 @@ impl QuantumResource for PasqalLocal {
         }
     }
 
-    async fn task_logs(&mut self, _task_id: &str) -> Result<String> {
-        Ok("There are no logs for this job.".to_string())
+    async fn task_logs(&mut self, task_id: &str) -> Result<String> {
+        match self.api_client.get_task_logs(task_id).await {
+            Ok(resp) => {
+                Ok(resp.logs)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     async fn target(&mut self) -> Result<Target> {


### PR DESCRIPTION
## Description of Change

Update `task_logs` interface for `PasqalLocal` quantum resource. 

`task_logs` now fetches logs from pasqal local's middleware [Warden](github.com/pasqal-io/warden).

Associated Warden PR introducing the relevant endpoint: https://github.com/pasqal-io/warden/pull/36 

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
