### PR TITLE
Fix build-and-test-wheels workflow step errors introduced by #121

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - ubuntu-24.04-ppc64le
+        #  - ubuntu-24.04-ppc64le
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
@@ -129,8 +129,10 @@ jobs:
         python-version: 3.12
     - name: Build QRMI wheels
       uses: pypa/cibuildwheel@v3.4.1
+      # Skip free-threaded python for qiskit installation
       env:
         CIBW_TEST_EXTRAS: all
+        CIBW_SKIP: "cp*t-*"
     - name: Upload QRMI wheels
       uses: actions/upload-artifact@v7
       if: ${{ success() }}


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Recent #121 causes workflow execution errors:
https://github.com/qiskit-community/qrmi/actions/runs/25409034406

This PR addresses tentative solutions for now:
- Skip build/test with free-threaded python (cp314t) to avoid an installation error of qiskit-2.4.1
- Disable ppc64le platform (python 3.12 is not available on our ppc64le runner)

@cclaudio is expected to review this PR.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
