### PR TITLE
Add docs test/example to qrmi::models::Config

### DIFF
--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -101,6 +101,22 @@ pub struct ResourceDefs {
 }
 
 /// QRMI configuration file
+///
+/// # Example
+///
+/// ```no_run
+/// use qrmi::models::Config;
+/// 
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let config = Config::load("./qrmi_example_config.json")?;
+///
+/// if let Some(resource) = config.resource_map.get("ibm_osaka") {
+///     println!("Found resource: {}", resource.name);
+///     println!("Type: {:?}", resource.r#type);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub struct Config {
     pub resource_map: HashMap<String, ResourceDef>,
 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -113,6 +113,9 @@ pub struct ResourceDefs {
 /// if let Some(resource) = config.resource_map.get("ibm_osaka") {
 ///     println!("Found resource: {}", resource.name);
 ///     println!("Type: {:?}", resource.r#type);
+///     for (key, value) in &resource.environment {
+///         println!("Environment variable: {}={}", key, value);
+///     }
 /// }
 /// # Ok(())
 /// # }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -106,7 +106,7 @@ pub struct ResourceDefs {
 ///
 /// ```no_run
 /// use qrmi::models::Config;
-/// 
+///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let config = Config::load("./qrmi_example_config.json")?;
 ///


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->

This PR adds a docs example/test to the `Config` struct in `src/models/config.rs`. I added this to my local branch for illustrative purposes initially, though it seems worthwhile to add to the codebase to provide a compiler-verified example demonstrating how a user should instantiate the config file and access resources

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Tests

- [x] Verified the example compiles via `cargo test --doc`.
- [x] Verified HTML renders correctly (locally) via `cargo doc`.
- [x] Change was formatted with `cargo fmt`.

## Ticket
- [ ] Fixes #
- [ ] Is Part of #

