### PR TITLE
[PASQAL] Update Pasqal Cloud `is_accessible` behavior to call public endpoint

### DIFF
--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -191,12 +191,15 @@ impl Client {
         Ok(())
     }
 
+    // Pasqal Cloud gets devices during `is_accessible` call.
+    // We we the public api endpoint with no auth token required
+    // so that the Spank plugin does not need any authentication setup.
     pub async fn get_device(&mut self, device_type: DeviceType) -> Result<GetDeviceResponseData> {
         let url = format!(
             "{}/core-fast/api/v1/devices?device_type={}",
             self.base_url, device_type,
         );
-        let resp: Response<Vec<GetDeviceResponseData>> = self.get(&url).await?;
+        let resp: Response<Vec<GetDeviceResponseData>> = self.get_raw(&url).await?;
 
         resp.data
             .into_iter()
@@ -321,6 +324,12 @@ impl Client {
             .await?
             .send()
             .await?;
+        self.handle_request(resp).await
+    }
+
+    // Unauthenticated GET request for public endpoints
+    pub(crate) async fn get_raw<T: DeserializeOwned>(&mut self, url: &str) -> Result<T> {
+        let resp = self.client.get(url).send().await?;
         self.handle_request(resp).await
     }
 

--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -192,7 +192,7 @@ impl Client {
     }
 
     // Pasqal Cloud gets devices during `is_accessible` call.
-    // We we the public api endpoint with no auth token required
+    // We get the public api endpoint with no auth token required
     // so that the Spank plugin does not need any authentication setup.
     pub async fn get_device(&mut self, device_type: DeviceType) -> Result<GetDeviceResponseData> {
         let url = format!(

--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -199,7 +199,7 @@ impl Client {
             "{}/core-fast/api/v1/devices?device_type={}",
             self.base_url, device_type,
         );
-        let resp: Response<Vec<GetDeviceResponseData>> = self.get_raw(&url).await?;
+        let resp: Response<Vec<GetDeviceResponseData>> = self.get_unauthenticated(&url).await?;
 
         resp.data
             .into_iter()
@@ -328,7 +328,7 @@ impl Client {
     }
 
     // Unauthenticated GET request for public endpoints
-    pub(crate) async fn get_raw<T: DeserializeOwned>(&mut self, url: &str) -> Result<T> {
+    pub(crate) async fn get_unauthenticated<T: DeserializeOwned>(&mut self, url: &str) -> Result<T> {
         let resp = self.client.get(url).send().await?;
         self.handle_request(resp).await
     }

--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -328,7 +328,10 @@ impl Client {
     }
 
     // Unauthenticated GET request for public endpoints
-    pub(crate) async fn get_unauthenticated<T: DeserializeOwned>(&mut self, url: &str) -> Result<T> {
+    pub(crate) async fn get_unauthenticated<T: DeserializeOwned>(
+        &mut self,
+        url: &str,
+    ) -> Result<T> {
         let resp = self.client.get(url).send().await?;
         self.handle_request(resp).await
     }

--- a/src/pasqal/cloud.rs
+++ b/src/pasqal/cloud.rs
@@ -13,7 +13,7 @@
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use crate::QuantumResource;
 use anyhow::{anyhow, bail, Result};
-use log::{debug, error, warn};
+use log::{debug, warn};
 use pasqal_cloud_api::{Client, ClientBuilder, DeviceType, JobStatus};
 use std::collections::HashMap;
 use std::env;
@@ -251,7 +251,7 @@ impl PasqalCloud {
         } else if let Some(token) = auth_token {
             builder.with_token(token);
         } else {
-            error!(
+            debug!(
                 "No Pasqal Cloud auth details configured for backend '{}': expected PASQAL_USERNAME/PASQAL_PASSWORD, ~/.pasqal/config credentials, or token",
                 backend_name
             );

--- a/src/pasqal/tests/cloud.rs
+++ b/src/pasqal/tests/cloud.rs
@@ -10,34 +10,26 @@ use std::net::TcpListener;
 use std::thread;
 
 #[tokio::test]
-async fn is_accessible_attempts_authentication() {
-    // This test verifies that `is_accessible()` attempts to authenticate and uses the obtained token.
-    // We set up a mock server that simulates the authentication endpoint and the devices endpoint.
-    // The server will respond with a fixed token for the authentication request and will check that this token is used in the subsequent request to the devices endpoint.
-    // We also verify that `is_accessible()` returns true, indicating that the backend is accessible with the obtained token.
+async fn is_accessible_no_authentication() {
+    // This test verifies that `is_accessible()` does not need to authenticate.
+    // We set up a mock server that simulates the devices endpoint.
+    // We also verify that `is_accessible()` returns true, indicating that the backend is accessible.
 
     // Ask for any free port.
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind should succeed");
     let addr = listener.local_addr().expect("local_addr should succeed");
     // Setup Mock server with mocked responses.
     let mock_server = thread::spawn(move || {
-        for _ in 0..2 {
+        for _ in 0..1 {
             if let Ok((mut stream, _)) = listener.accept() {
                 // Read the request
                 let mut buf = [0_u8; 4096];
                 let n = stream.read(&mut buf).unwrap_or(0);
                 let req = String::from_utf8_lossy(&buf[..n]);
-                let req_lower = req.to_ascii_lowercase();
+                assert!(req.contains("/core-fast/api/v1/devices"));
 
-                // hardcode responses based on the request path
-                let body = if req.contains("/oauth/token") {
-                    r#"{"access_token":"opaque_token"}"#
-                } else if req.contains("/core-fast/api/v1/devices") {
-                    assert!(req_lower.contains("authorization: bearer opaque_token"));
-                    r#"{"data":[{"status":"UP","availability":"ACTIVE"}]}"#
-                } else {
-                    r#"{}"#
-                };
+                // Hardcode response
+                let body = r#"{"data":[{"status":"UP","availability":"ACTIVE"}]}"#;
 
                 // Write the response
                 let response = format!(
@@ -53,8 +45,6 @@ async fn is_accessible_attempts_authentication() {
 
     let mut builder = ClientBuilder::new("project-id".to_string());
     builder.with_base_url(format!("http://{}", addr));
-    builder.with_auth_endpoint(format!("http://{}/oauth/token", addr));
-    builder.with_credentials("usr".to_string(), "pass".to_string());
     let api_client = builder.build().expect("client build should succeed");
 
     // Create a PasqalCloud instance pointing to the mock server


### PR DESCRIPTION
## Description of Change

We update the `is_accessible` call for pasqal-coud implementation to use a public API endpoint with no auth needed.
This removes the need for the Spank plugin to have any authentication for pasqal-cloud resources so that we can setup pasqal-cloud access in the user-env only.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
