### PR TITLE
[PASQAL] Add Pasqal Local client route to cancel job and implement `task_stop`

### DIFF
--- a/dependencies/pasqal_local_client/src/client.rs
+++ b/dependencies/pasqal_local_client/src/client.rs
@@ -142,9 +142,9 @@ impl Client {
     }
 
     pub async fn cancel_job(&self, job_id: &str) -> Result<JobResponse> {
-        let url = format!("{}/jobs/{}", self.base_url, job_id);
+        let url = format!("{}/jobs/{}/cancel", self.base_url, job_id);
         let headers = self.create_headers().await?;
-        let resp = self.client.delete(url).headers(headers).send().await?;
+        let resp = self.client.post(url).headers(headers).send().await?;
 
         self.handle_request(resp).await
     }

--- a/dependencies/pasqal_local_client/src/client.rs
+++ b/dependencies/pasqal_local_client/src/client.rs
@@ -141,6 +141,14 @@ impl Client {
         self.handle_request(resp).await
     }
 
+    pub async fn cancel_job(&self, job_id: &str) -> Result<JobResponse> {
+        let url = format!("{}/jobs/{}", self.base_url, job_id);
+        let headers = self.create_headers().await?;
+        let resp = self.client.delete(url).headers(headers).send().await?;
+
+        self.handle_request(resp).await
+    }
+
     pub async fn get_accessible(&self) -> Result<AccessibleResponse> {
         let url = format!("{}/accessible", self.base_url);
 

--- a/python/qrmi/pulser/connection.py
+++ b/python/qrmi/pulser/connection.py
@@ -37,7 +37,7 @@ from pulser.result import SampledResult
 from qrmi import Payload, QuantumResource, TaskStatus, ResourceType  # type: ignore
 from qrmi.pulser.service import QRMIService
 
-logger = logging.getLogger("qrmi")
+logger = logging.getLogger(__name__)
 
 _QRMI_TASK_STATUS_MAP: dict[TaskStatus, JobStatus] = {
     TaskStatus.Queued: JobStatus.PENDING,
@@ -79,7 +79,8 @@ class PulserQRMIConnection(RemoteConnection):
         _type: ResourceType = self._qrmi.resource_type()
         if _type not in _COMPATIBLE_RESOURCE_TYPES:
             raise ValueError(
-                "PulserQRMIConnection can only be used with 'PasqalLocal' or 'PasqalCloud' QRMI resources,"
+                "PulserQRMIConnection can only be used with 'PasqalLocal' "
+                "or 'PasqalCloud' QRMI resources,"
                 f" got: '{_type}'"
             )
 
@@ -130,9 +131,9 @@ class PulserQRMIConnection(RemoteConnection):
         return devices
 
     def get_batch_logs(self, batch_id: str | None = None) -> Sequence[str]:
-        """Get the logs from the current batch through the `task_logs` interface."""
+        """Get the logs from the batch through the `qrmi.task_logs` interface."""
         if batch_id is None:
-            logger.debug("No batch ID provided, fetching logs from last batch")
+            logger.info("No batch ID provided, fetching logs from last batch")
             batch_id = self._current_batch_id
 
         job_ids = self._get_job_ids(batch_id)
@@ -140,11 +141,23 @@ class PulserQRMIConnection(RemoteConnection):
         for job_id in job_ids:
             try:
                 job_logs = self._qrmi.task_logs(job_id)
-            except RuntimeError:
-                logger.exception("Failed to fetch logs for job %s", job_id)
-                raise
+            except RuntimeError as e:
+                logger.warning("Failed to fetch logs for job %s: %s", job_id, e)
             logs.append(job_logs)
         return tuple(logs)
+
+    def cancel_batch_jobs(self, batch_id: str | None = None) -> None:
+        """Cancel all jobs in the batch through the `qrmi.task_stop` interface."""
+        if batch_id is None:
+            logger.info("No batch ID provided, stopping logs from last batch")
+            batch_id = self._current_batch_id
+
+        job_ids = self._get_job_ids(batch_id)
+        for job_id in job_ids:
+            try:
+                self._qrmi.task_stop(job_id)
+            except RuntimeError as e:
+                logger.warning("Failed to stop job %s: %s", job_id, e)
 
     def _fetch_result(
         self, batch_id: str, job_ids: list[str] | None
@@ -307,8 +320,10 @@ class PulserQRMIConnection(RemoteConnection):
         return batch_id.split("|")
 
     def _close_batch(self, batch_id: str) -> None:
-        for job_id in self._get_job_ids(batch_id):
-            self._qrmi.task_stop(job_id)
+        """Closes a batch using its ID."""
+        raise NotImplementedError(  # pragma: no cover
+            "Unable to close batch through this remote connection"
+        )
 
     @staticmethod
     def _to_job_status(status: TaskStatus) -> JobStatus:

--- a/python/qrmi/pulser/connection.py
+++ b/python/qrmi/pulser/connection.py
@@ -141,8 +141,8 @@ class PulserQRMIConnection(RemoteConnection):
         for job_id in job_ids:
             try:
                 job_logs = self._qrmi.task_logs(job_id)
-            except RuntimeError as e:
-                logger.warning("Failed to fetch logs for job %s: %s", job_id, e)
+            except RuntimeError as err:
+                logger.warning("Failed to fetch logs for job %s: %s", job_id, err)
             logs.append(job_logs)
         return tuple(logs)
 
@@ -156,8 +156,8 @@ class PulserQRMIConnection(RemoteConnection):
         for job_id in job_ids:
             try:
                 self._qrmi.task_stop(job_id)
-            except RuntimeError as e:
-                logger.warning("Failed to stop job %s: %s", job_id, e)
+            except RuntimeError as err:
+                logger.warning("Failed to stop job %s: %s", job_id, err)
 
     def _fetch_result(
         self, batch_id: str, job_ids: list[str] | None

--- a/src/pasqal/local.rs
+++ b/src/pasqal/local.rs
@@ -114,8 +114,11 @@ impl QuantumResource for PasqalLocal {
         }
     }
 
-    async fn task_stop(&mut self, _task_id: &str) -> Result<()> {
-        Ok(())
+    async fn task_stop(&mut self, task_id: &str) -> Result<()> {
+        match self.api_client.cancel_job(task_id).await {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err),
+        }
     }
 
     async fn task_status(&mut self, task_id: &str) -> Result<TaskStatus> {


### PR DESCRIPTION
## Description of Change

Implement `task_stop` interface for PasqalLocal resources.
- Adds a new method to the PasqalLocal client targetting the Warden middleware
- Corresponding Warden PR: https://github.com/pasqal-io/warden/pull/60

Adds a `cancel_batch_jobs` method to `PulserQRMIConnection` that wraps `task_stop` calls for Pasqal stack users.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
