### PR TITLE
Fix workspace.package.repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/qiskit-community/spank-plugins"
+repository = "https://github.com/qiskit-community/qrmi"
 rust-version = "1.85.1" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 [workspace.dependencies]

--- a/examples/qrmi/rust/Cargo.toml
+++ b/examples/qrmi/rust/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/qiskit-community/spank-plugins"
+repository = "https://github.com/qiskit-community/qrmi"
 rust-version = "1.85.1" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 [workspace.dependencies]

--- a/examples/qrmi/rust/pasqal_cloud/Cargo.toml
+++ b/examples/qrmi/rust/pasqal_cloud/Cargo.toml
@@ -3,7 +3,7 @@ name = "qrmi-example-pasqal-cloud"
 version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/qiskit-community/spank-plugins"
+repository = "https://github.com/qiskit-community/qrmi"
 rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 

--- a/examples/qrmi/rust/pasqal_local/Cargo.toml
+++ b/examples/qrmi/rust/pasqal_local/Cargo.toml
@@ -3,7 +3,7 @@ name = "qrmi-example-pasqal-local"
 version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/qiskit-community/spank-plugins"
+repository = "https://github.com/qiskit-community/qrmi"
 rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 

--- a/examples/qrmi/rust/qiskit_runtime_service/Cargo.toml
+++ b/examples/qrmi/rust/qiskit_runtime_service/Cargo.toml
@@ -3,7 +3,7 @@ name = "qrmi-example-qiskit_runtime_service"
 version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/qiskit-community/spank-plugins"
+repository = "https://github.com/qiskit-community/qrmi"
 rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 

--- a/examples/qrmi/rust/qrmi_config/Cargo.toml
+++ b/examples/qrmi/rust/qrmi_config/Cargo.toml
@@ -3,7 +3,7 @@ name = "qrmi-example-config"
 version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/qiskit-community/spank-plugins"
+repository = "https://github.com/qiskit-community/qrmi"
 rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 

--- a/examples/qrmi/rust/resource_providers/Cargo.toml
+++ b/examples/qrmi/rust/resource_providers/Cargo.toml
@@ -3,7 +3,7 @@ name = "qrmi-example-provider"
 version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/qiskit-community/spank-plugins"
+repository = "https://github.com/qiskit-community/qrmi"
 rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Currently, our Cargo.toml files describe spank-plugins repo as workspace.package.repository. It probably got missed when we split the git repository. This PR will fix it properly. 

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
