### PR TITLE
Handle job error correctly in IBM examples

### DIFF
--- a/examples/qiskit_primitives/ibm/estimator.py
+++ b/examples/qiskit_primitives/ibm/estimator.py
@@ -75,10 +75,13 @@ job = estimator.run([(isa_circuit, isa_observable, param_values)])
 print(f">>> Job ID: {job.job_id()}")
 print(f">>> Job Status: {job.status()}")
 
-result = job.result()
-print(f">>> {result}")
-print(f"  > Expectation value: {result[0].data.evs}")
-print(f"  > Metadata: {result[0].metadata}")
+try:
+    result = job.result()
+    print(f">>> {result}")
+    print(f"  > Expectation value: {result[0].data.evs}")
+    print(f"  > Metadata: {result[0].metadata}")
+except RuntimeError as err:
+    print(err)
 
 if job.errored():
     print(qrmi.task_logs(job.job_id()))

--- a/examples/qiskit_primitives/ibm/sampler.py
+++ b/examples/qiskit_primitives/ibm/sampler.py
@@ -66,11 +66,14 @@ sampler = SamplerV2(qrmi, options=options)
 job = sampler.run([(isa_circuit, param_values)])
 print(f">>> Job ID: {job.job_id()}")
 print(f">>> Job Status: {job.status()}")
-result = job.result()
+try:
+    result = job.result()
 
-# Get results for the first (and only) PUB
-pub_result = result[0]
-print(f"Counts for the 'meas' output register: {pub_result.data.meas.get_counts()}")
+    # Get results for the first (and only) PUB
+    pub_result = result[0]
+    print(f"Counts for the 'meas' output register: {pub_result.data.meas.get_counts()}")
+except RuntimeError as err:
+    print(err)
 
 if job.errored():
     print(qrmi.task_logs(job.job_id()))


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
This PR will improve error handling of IBM's sampler/estimator examples.

Since the current sampler/estimator examples try to retrieve the result without first confirming that the job has completed, an exception gets raised at that point. Result is only available if job is succeeded.

```
Traceback (most recent call last):
  File "/shared/qrmi/examples/qiskit_primitives/ibm/sampler.py", line 69, in <module>
    result = job.result()
             ^^^^^^^^^^^^
  File "/shared/pyenv/lib64/python3.12/site-packages/qrmi/primitives/runtime_job_v2.py", line 72, in result
    result = self._qrmi.task_result(self._job_id)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Unable to retrieve result for task 5a4015c2-8221-4da5-96d4-12d840db3ff9. Task failed. code: , message: Exception: Error fetching parameters from url, solution:
srun: error: c1: task 0: Exited with exit code 1
```


## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
