### PR TITLE
Fix ModuleNotFoundError: No module named 'qiskit_ibm_runtime.utils.RuntimeEncoder'

### DIFF
--- a/examples/task_runner/qiskit/gen_estimator_inputs.py
+++ b/examples/task_runner/qiskit/gen_estimator_inputs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,7 +21,7 @@ import requests
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 
 from qiskit_ibm_runtime.utils.backend_converter import convert_to_target
-from qiskit_ibm_runtime.utils import RuntimeEncoder
+from qiskit_ibm_runtime import RuntimeEncoder
 from qiskit_ibm_runtime.models import BackendProperties, BackendConfiguration
 from qiskit import qasm3
 from qiskit.circuit.library import QAOAAnsatz

--- a/examples/task_runner/qiskit/gen_sampler_inputs.py
+++ b/examples/task_runner/qiskit/gen_sampler_inputs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# (C) Copyright 2025 IBM. All Rights Reserved.
+# (C) Copyright 2025, 2026 IBM. All Rights Reserved.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -19,7 +19,7 @@ import argparse
 import requests
 
 import numpy as np
-from qiskit_ibm_runtime.utils import RuntimeEncoder
+from qiskit_ibm_runtime import RuntimeEncoder
 from qiskit_ibm_runtime.utils.backend_converter import convert_to_target
 from qiskit_ibm_runtime.models import BackendProperties, BackendConfiguration
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
Those python module path changes were introduced in recent qiskit-ibm-runtime updates. Need to adapt to those changes. Unfortunately, 2 files should also be updated but were not covered in #166.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [x] Is Part of #166
