### PR TITLE
Fix Alice & Bob Felis API tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -144,6 +144,16 @@
         "is_secret": false
       }
     ],
+    "dependencies/alice_bob_felis_client/tests/api.rs": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "dependencies/alice_bob_felis_client/tests/api.rs",
+        "hashed_secret": "508772f1d9a379283d0984d21280ccfbec215f8b",
+        "is_verified": false,
+        "line_number": 4,
+        "is_secret": false
+      }
+    ],
     "dependencies/quantum_system_client/README.md": [
       {
         "type": "Secret Keyword",
@@ -481,5 +491,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-15T06:11:13Z"
+  "generated_at": "2026-08-12T13:48:08Z"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "dotenvy",
  "felis-generated",
+ "mockito",
  "reqwest",
  "serde",
  "serde_json",
@@ -927,12 +927,6 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"

--- a/dependencies/alice_bob_felis_client/Cargo.toml
+++ b/dependencies/alice_bob_felis_client/Cargo.toml
@@ -21,7 +21,7 @@ reqwest = { version = "^0.12", default-features = false, features = ["json", "mu
 
 
 [dev-dependencies]
-dotenvy = "0.15.7"
+mockito = "1.5.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [features]

--- a/dependencies/alice_bob_felis_client/tests/api.rs
+++ b/dependencies/alice_bob_felis_client/tests/api.rs
@@ -1,7 +1,7 @@
 use alice_bob_felis::apis::{configuration, health_service, targets_service};
 use alice_bob_felis::helpers::decode_api_key;
 
-const API_KEY: &str = "dXNlcjpwYXNzd29yZA=="; // pragma: allowlist secret
+const API_KEY: &str = "bW9jay1mZWxpcy11c2VyOm1vY2stZmVsaXMtcGFzc3dvcmQ=";
 
 fn prepare_config(endpoint: String) -> configuration::Configuration {
     let mut config = configuration::Configuration::new();

--- a/dependencies/alice_bob_felis_client/tests/api.rs
+++ b/dependencies/alice_bob_felis_client/tests/api.rs
@@ -1,31 +1,50 @@
-use anyhow::Result;
-use dotenvy::dotenv;
-use felis::apis::{configuration, health_service, targets_service};
-use felis::helpers::decode_api_key;
+use alice_bob_felis::apis::{configuration, health_service, targets_service};
+use alice_bob_felis::helpers::decode_api_key;
 
-async fn prepare_config() -> Result<configuration::Configuration, anyhow::Error> {
-    dotenv().ok();
-    let api_key = std::env::var("FELIS_API_KEY")?;
-    let endpoint = std::env::var("FELIS_BASE_ENDPOINT")?;
+const API_KEY: &str = "dXNlcjpwYXNzd29yZA=="; // pragma: allowlist secret
 
+fn prepare_config(endpoint: String) -> configuration::Configuration {
     let mut config = configuration::Configuration::new();
     config.base_path = endpoint;
-    config.basic_auth = decode_api_key(&api_key).unwrap();
+    config.basic_auth = decode_api_key(API_KEY).unwrap();
 
-    Ok(config)
+    config
 }
 
 #[tokio::test]
-async fn test_health_check() -> Result<(), anyhow::Error> {
-    let config = prepare_config().await?;
-    let response = health_service::check_health(&config, None).await?;
+async fn test_health_check() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/v1/health/")
+        .match_header("authorization", format!("Basic {API_KEY}").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("\"OK\"")
+        .create_async()
+        .await;
+
+    let config = prepare_config(server.url());
+    let response = health_service::check_health(&config, None).await.unwrap();
+
     assert_eq!(response, "OK");
-    Ok(())
+    mock.assert_async().await;
 }
 
 #[tokio::test]
-async fn test_list_targets() -> Result<(), anyhow::Error> {
-    let config = prepare_config().await?;
-    targets_service::list_targets(&config).await?;
-    Ok(())
+async fn test_list_targets() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/v1/targets/")
+        .match_header("authorization", format!("Basic {API_KEY}").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body("[]")
+        .create_async()
+        .await;
+
+    let config = prepare_config(server.url());
+    let response = targets_service::list_targets(&config).await.unwrap();
+
+    assert!(response.is_empty());
+    mock.assert_async().await;
 }


### PR DESCRIPTION
## Description of Change

The Alice & Bob Felis API tests referenced the old `felis` crate name and no longer compiled. This updates the imports and runs the health and target-list tests against a local mock server, so `cargo test` does not require Felis credentials or network access.

## Checklist ✅

- [x] Included a description of the change.
- [x] Documentation is not needed for this test-only change.
- [x] Local Rust tests, formatting, and lint checks pass.

## Ticket

- [x] Fixes #186
- [ ] Is Part of #