### PR TITLE
Bridge Rust log records to Python's logging module (and fix a GIL deadlock in blocking calls)

### DIFF
--- a/src/cext.rs
+++ b/src/cext.rs
@@ -34,7 +34,13 @@ pub enum ReturnCode {
     NullPointerError = 101,
 }
 
-pub type QrmiLogCallback = crate::common::QrmiLogCallback;
+/// C ABI type for `qrmi_log_callback_set`. This is a C-facing detail: it
+/// does not appear anywhere in `common.rs`, which only knows about plain
+/// Rust closures (see `common::LogSink`). `qrmi_log_callback_set` below
+/// adapts one of these into a `LogSink` at registration time.
+pub type QrmiLogCallback = Option<
+    unsafe extern "C" fn(level: *const c_char, target: *const c_char, message: *const c_char),
+>;
 
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq)]
@@ -181,6 +187,24 @@ fn _set_last_error(msg: String) {
     });
 }
 
+/// Converts a Rust string into a `CString` suitable for handing across the
+/// C ABI, stripping any embedded NUL bytes first (a `&str` may contain
+/// them; a C string cannot). Used only at the C boundary -- see
+/// `qrmi_log_callback_set`'s adapter closure -- because this is where
+/// Rust's log records get converted to the C-callable log callback's
+/// pointer arguments.
+fn sanitized_cstring(value: &str) -> CString {
+    CString::new(
+        value
+            .as_bytes()
+            .iter()
+            .copied()
+            .filter(|byte| *byte != 0)
+            .collect::<Vec<_>>(),
+    )
+    .unwrap_or_default()
+}
+
 /// @ingroup Qrmi
 /// Registers a QRMI log callback for C hosts.
 ///
@@ -213,7 +237,22 @@ fn _set_last_error(msg: String) {
 /// @version 0.20.0
 #[no_mangle]
 pub unsafe extern "C" fn qrmi_log_callback_set(callback: QrmiLogCallback) -> ReturnCode {
-    let result = crate::common::set_log_callback(callback);
+    let sink: Option<crate::common::LogSink> = callback.map(|f| {
+        let adapter: crate::common::LogSink = std::sync::Arc::new(move |level, target, message| {
+            let level = sanitized_cstring(level.as_str());
+            let target = sanitized_cstring(target);
+            let message = sanitized_cstring(message);
+            // SAFETY: `f` is a C function pointer supplied by the caller of
+            // `qrmi_log_callback_set`, which documents the same validity
+            // requirement this closure now carries: `f` must remain valid
+            // and callable for as long as it might still be invoked.
+            unsafe {
+                f(level.as_ptr(), target.as_ptr(), message.as_ptr());
+            }
+        });
+        adapter
+    });
+    let result = crate::common::set_log_sink(sink);
     crate::common::initialize();
     match result {
         Ok(()) => ReturnCode::Success,

--- a/src/common.rs
+++ b/src/common.rs
@@ -56,9 +56,20 @@ fn dispatch_to_sink(record: &log::Record<'_>) -> bool {
 }
 
 /// Called once before using the API library to initialize static resources(logger etc.) in underlying layers. If called more than once, the second and subsequent calls are ignored.
+///
+/// Uses `try_init()`, not `init()`: `init()` panics if another library in
+/// the same process already registered a `log` logger first (only one can
+/// ever be registered process-wide), and -- because that failure happens
+/// inside this `Once::call_once` closure -- a panic here poisons `INIT`,
+/// so every later call to `initialize()` (this runs at the top of nearly
+/// every QRMI entry point) panics too, for the rest of the process's
+/// lifetime. `try_init()` fails quietly instead: if we lose that race,
+/// QRMI's `log` output is simply not registered (records fall through to
+/// whichever logger did win), rather than taking down every subsequent
+/// call into QRMI.
 pub(crate) fn initialize() {
     INIT.call_once(|| {
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
+        let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
             .format(|buf, record| {
                 if dispatch_to_sink(record) {
                     Ok(())
@@ -73,6 +84,6 @@ pub(crate) fn initialize() {
                     )
                 }
             })
-            .init();
+            .try_init();
     });
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,48 +9,49 @@
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
-use std::ffi::CString;
 use std::io::Write;
-use std::os::raw::c_char;
-use std::sync::{Once, RwLock};
+use std::sync::{Arc, Once, RwLock};
 
 static INIT: Once = Once::new();
-static LOG_CALLBACK: RwLock<QrmiLogCallback> = RwLock::new(None);
+static LOG_SINK: RwLock<Option<LogSink>> = RwLock::new(None);
 
-pub type QrmiLogCallback = Option<
-    unsafe extern "C" fn(level: *const c_char, target: *const c_char, message: *const c_char),
->;
+/// A destination for `log` records, in plain Rust terms: no C ABI, no
+/// pointers. `cext` and `pyext` each register their own adapter here --
+/// `cext`'s wraps a C function pointer and does the `CString` conversion
+/// at dispatch time (see `cext::qrmi_log_callback_set`); `pyext`'s calls
+/// straight into Python's `logging` module, or into a user-supplied
+/// Python callable (see `pyext::set_log_callback`). Neither shape leaks
+/// into this module.
+///
+/// `Arc` rather than `Box`: `dispatch_to_sink` below clones this handle
+/// and releases `LOG_SINK`'s lock *before* calling it, since a sink may
+/// call arbitrary code (a user's own Python callback in particular) that
+/// could be slow or could itself log again on the same thread --
+/// `std::sync::RwLock` does not guarantee safe recursive read-locking, so
+/// still holding the lock across that call would risk a deadlock or worse.
+pub(crate) type LogSink = Arc<dyn Fn(log::Level, &str, &str) + Send + Sync>;
 
-pub(crate) fn set_log_callback(callback: QrmiLogCallback) -> Result<(), ()> {
-    LOG_CALLBACK
+/// Registers `sink` as the destination for future `log` records, replacing
+/// any previously registered sink. `None` clears it, reverting to plain
+/// stderr output.
+pub(crate) fn set_log_sink(sink: Option<LogSink>) -> Result<(), ()> {
+    LOG_SINK
         .write()
-        .map(|mut current| *current = callback)
+        .map(|mut current| *current = sink)
         .map_err(|_| ())
 }
 
-fn sanitized_cstring(value: &str) -> CString {
-    CString::new(
-        value
-            .as_bytes()
-            .iter()
-            .copied()
-            .filter(|byte| *byte != 0)
-            .collect::<Vec<_>>(),
-    )
-    .unwrap_or_default()
-}
-
-fn dispatch_to_callback(record: &log::Record<'_>) -> bool {
-    let callback = LOG_CALLBACK.read().ok().and_then(|current| *current);
-    let Some(callback) = callback else {
+fn dispatch_to_sink(record: &log::Record<'_>) -> bool {
+    let sink = {
+        let Ok(guard) = LOG_SINK.read() else {
+            return false;
+        };
+        guard.clone()
+    };
+    let Some(sink) = sink else {
         return false;
     };
-    let level = sanitized_cstring(record.level().as_str());
-    let target = sanitized_cstring(record.target());
-    let message = sanitized_cstring(&record.args().to_string());
-    unsafe {
-        callback(level.as_ptr(), target.as_ptr(), message.as_ptr());
-    }
+    sink(record.level(), record.target(), &record.args().to_string());
     true
 }
 
@@ -59,7 +60,7 @@ pub(crate) fn initialize() {
     INIT.call_once(|| {
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
             .format(|buf, record| {
-                if dispatch_to_callback(record) {
+                if dispatch_to_sink(record) {
                     Ok(())
                 } else {
                     writeln!(

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -40,7 +40,31 @@ pub enum ResourceType {
 #[pyo3(name = "QuantumResource")]
 pub struct PyQuantumResource {
     qrmi: Box<dyn QuantumResource + Send + Sync>,
-    rt: Runtime,
+    // `ManuallyDrop`, not a plain `Runtime`, so `Drop` below can take
+    // ownership and call `shutdown_background()` instead of letting the
+    // field's own destructor run. Existing `self.rt.block_on(...)` call
+    // sites are unaffected: `ManuallyDrop<T>` derefs to `T` transparently.
+    rt: std::mem::ManuallyDrop<Runtime>,
+}
+
+impl Drop for PyQuantumResource {
+    fn drop(&mut self) {
+        // `Runtime`'s own `Drop` blocks the current thread indefinitely
+        // until every spawned task finishes. That is a problem here
+        // specifically: Python drops objects while holding the GIL, and
+        // if a worker thread needs the GIL to log something (e.g. an
+        // in-flight HTTP request logged at `RUST_LOG=trace`) before it can
+        // finish, that worker waits for the GIL forever while this thread
+        // waits for that worker forever. `shutdown_background()` discards
+        // the runtime without waiting for anything, which avoids the
+        // deadlock entirely (in exchange for not waiting for in-flight
+        // background work to finish cleanly on drop).
+        //
+        // SAFETY: `self.rt` is only ever taken here, in `Drop::drop`,
+        // which runs at most once per instance.
+        let rt = unsafe { std::mem::ManuallyDrop::take(&mut self.rt) };
+        rt.shutdown_background();
+    }
 }
 
 impl PyQuantumResource {
@@ -48,7 +72,9 @@ impl PyQuantumResource {
     pub(crate) fn from_inner(qrmi: Box<dyn QuantumResource + Send + Sync>) -> Self {
         Self {
             qrmi,
-            rt: Runtime::new().unwrap(),
+            rt: std::mem::ManuallyDrop::new(
+                Runtime::new().expect("Failed to create a new tokio runtime."),
+            ),
         }
     }
 }
@@ -102,7 +128,9 @@ impl PyQuantumResource {
 
         Ok(Self {
             qrmi,
-            rt: Runtime::new().unwrap(),
+            rt: std::mem::ManuallyDrop::new(
+                Runtime::new().expect("Failed to create a new tokio runtime."),
+            ),
         })
     }
 
@@ -313,7 +341,20 @@ impl PyResourceDef {
 #[pyo3(name = "ResourceProvider")]
 pub struct PyResourceProvider {
     inner: Box<dyn crate::ResourceProvider>,
-    rt: Runtime,
+    // See `PyQuantumResource`'s `rt` field and `Drop` impl for why this is
+    // `ManuallyDrop` rather than a plain `Runtime`.
+    rt: std::mem::ManuallyDrop<Runtime>,
+}
+
+impl Drop for PyResourceProvider {
+    fn drop(&mut self) {
+        // See `PyQuantumResource`'s `Drop` impl for why.
+        //
+        // SAFETY: `self.rt` is only ever taken here, in `Drop::drop`,
+        // which runs at most once per instance.
+        let rt = unsafe { std::mem::ManuallyDrop::take(&mut self.rt) };
+        rt.shutdown_background();
+    }
 }
 
 #[gen_stub_pymethods]
@@ -349,7 +390,9 @@ impl PyResourceProvider {
         };
         Ok(Self {
             inner,
-            rt: Runtime::new().unwrap(),
+            rt: std::mem::ManuallyDrop::new(
+                Runtime::new().expect("Failed to create a new tokio runtime."),
+            ),
         })
     }
 
@@ -489,6 +532,15 @@ impl PyConfig {
 /// particular sink happens to call into Python; that's this module's
 /// business alone. Compare `cext::qrmi_log_callback_set`, which adapts a
 /// C function pointer into the same `LogSink` shape at its own boundary.
+///
+/// Uses `Python::try_attach`, not `Python::attach`: a log record can be
+/// emitted from a `__del__` running during CPython interpreter
+/// finalization (`Py_FinalizeEx`) -- attempting to (re-)acquire the GIL
+/// in that window is a known hazard (documented on `Python::attach`
+/// itself, and the subject of e.g. PyO3#5317: repeatedly attaching during
+/// finalization has hung or segfaulted). `try_attach` returns `None`
+/// instead in that case; we simply drop the record rather than risk
+/// hanging the interpreter shutdown to deliver a log line.
 fn python_log_sink(level: log::Level, target: &str, message: &str) {
     // Python's `logging` module level numbers (see Python's `logging`
     // module docs / `Lib/logging/__init__.py`: CRITICAL=50, ERROR=40,
@@ -504,7 +556,7 @@ fn python_log_sink(level: log::Level, target: &str, message: &str) {
         log::Level::Debug | log::Level::Trace => 10,
     };
 
-    Python::attach(|py| {
+    Python::try_attach(|py| {
         let Ok(logging) = py.import("logging") else {
             return;
         };
@@ -544,6 +596,10 @@ fn python_log_sink(level: log::Level, target: &str, message: &str) {
 /// - If `callback` raises, the exception is printed (as an unhandled
 ///   exception would be) and otherwise discarded; it cannot propagate
 ///   back into the Rust code that logged in the first place.
+/// - Like `python_log_sink`, this uses `Python::try_attach`: if a record
+///   is emitted while the interpreter is finalizing, `callback` is simply
+///   not called for it rather than risking the same hang/segfault hazard
+///   `Python::attach` has in that window.
 #[gen_stub_pyfunction]
 #[pyfunction]
 fn set_log_callback(callback: Option<Py<PyAny>>) -> PyResult<()> {
@@ -551,7 +607,7 @@ fn set_log_callback(callback: Option<Py<PyAny>>) -> PyResult<()> {
     let sink: Option<crate::common::LogSink> = callback.map(|callback| {
         let sink: crate::common::LogSink =
             std::sync::Arc::new(move |level: log::Level, target: &str, message: &str| {
-                Python::attach(|py| {
+                Python::try_attach(|py| {
                     if let Err(err) = callback.call1(py, (level.as_str(), target, message)) {
                         err.print(py);
                     }

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -106,27 +106,27 @@ impl PyQuantumResource {
         })
     }
 
-    fn is_accessible(&mut self) -> PyResult<bool> {
+    fn is_accessible(&mut self, py: Python<'_>) -> PyResult<bool> {
         crate::common::initialize();
-        let result = self.rt.block_on(async { self.qrmi.is_accessible().await });
+        let result = py.detach(|| self.rt.block_on(async { self.qrmi.is_accessible().await }));
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn resource_id(&mut self) -> PyResult<String> {
+    fn resource_id(&mut self, py: Python<'_>) -> PyResult<String> {
         crate::common::initialize();
-        let result = self.rt.block_on(async { self.qrmi.resource_id().await });
+        let result = py.detach(|| self.rt.block_on(async { self.qrmi.resource_id().await }));
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn resource_type(&mut self) -> PyResult<ResourceType> {
+    fn resource_type(&mut self, py: Python<'_>) -> PyResult<ResourceType> {
         crate::common::initialize();
-        let result = self.rt.block_on(async { self.qrmi.resource_type().await });
+        let result = py.detach(|| self.rt.block_on(async { self.qrmi.resource_type().await }));
         match result {
             Ok(v) => Ok(match v {
                 crate::models::ResourceType::IBMQuantumSystem => ResourceType::IBMQuantumSystem,
@@ -142,91 +142,96 @@ impl PyQuantumResource {
         }
     }
 
-    fn acquire(&mut self) -> PyResult<String> {
+    fn acquire(&mut self, py: Python<'_>) -> PyResult<String> {
         crate::common::initialize();
-        let result = self.rt.block_on(async { self.qrmi.acquire().await });
+        let result = py.detach(|| self.rt.block_on(async { self.qrmi.acquire().await }));
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn release(&mut self, id: &str) -> PyResult<()> {
+    fn release(&mut self, py: Python<'_>, id: &str) -> PyResult<()> {
         crate::common::initialize();
-        let result = self.rt.block_on(async { self.qrmi.release(id).await });
+        let result = py.detach(|| self.rt.block_on(async { self.qrmi.release(id).await }));
         match result {
             Ok(()) => Ok(()),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn task_start(&mut self, payload: Payload) -> PyResult<String> {
+    fn task_start(&mut self, py: Python<'_>, payload: Payload) -> PyResult<String> {
         crate::common::initialize();
-        let result = self
-            .rt
-            .block_on(async { self.qrmi.task_start(payload).await });
+        let result = py.detach(|| {
+            self.rt
+                .block_on(async { self.qrmi.task_start(payload).await })
+        });
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn task_stop(&mut self, task_id: &str) -> PyResult<()> {
+    fn task_stop(&mut self, py: Python<'_>, task_id: &str) -> PyResult<()> {
         crate::common::initialize();
-        let result = self
-            .rt
-            .block_on(async { self.qrmi.task_stop(task_id).await });
+        let result = py.detach(|| {
+            self.rt
+                .block_on(async { self.qrmi.task_stop(task_id).await })
+        });
         match result {
             Ok(()) => Ok(()),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn task_status(&mut self, task_id: &str) -> PyResult<TaskStatus> {
+    fn task_status(&mut self, py: Python<'_>, task_id: &str) -> PyResult<TaskStatus> {
         crate::common::initialize();
-        let result = self
-            .rt
-            .block_on(async { self.qrmi.task_status(task_id).await });
+        let result = py.detach(|| {
+            self.rt
+                .block_on(async { self.qrmi.task_status(task_id).await })
+        });
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn task_result(&mut self, task_id: &str) -> PyResult<TaskResult> {
+    fn task_result(&mut self, py: Python<'_>, task_id: &str) -> PyResult<TaskResult> {
         crate::common::initialize();
-        let result = self
-            .rt
-            .block_on(async { self.qrmi.task_result(task_id).await });
+        let result = py.detach(|| {
+            self.rt
+                .block_on(async { self.qrmi.task_result(task_id).await })
+        });
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn task_logs(&mut self, task_id: &str) -> PyResult<String> {
+    fn task_logs(&mut self, py: Python<'_>, task_id: &str) -> PyResult<String> {
         crate::common::initialize();
-        let result = self
-            .rt
-            .block_on(async { self.qrmi.task_logs(task_id).await });
+        let result = py.detach(|| {
+            self.rt
+                .block_on(async { self.qrmi.task_logs(task_id).await })
+        });
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn target(&mut self) -> PyResult<Target> {
+    fn target(&mut self, py: Python<'_>) -> PyResult<Target> {
         crate::common::initialize();
-        let result = self.rt.block_on(async { self.qrmi.target().await });
+        let result = py.detach(|| self.rt.block_on(async { self.qrmi.target().await }));
         match result {
             Ok(v) => Ok(v),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         }
     }
 
-    fn metadata(&mut self) -> PyResult<std::collections::HashMap<String, String>> {
+    fn metadata(&mut self, py: Python<'_>) -> PyResult<std::collections::HashMap<String, String>> {
         crate::common::initialize();
-        let result = self.rt.block_on(async { self.qrmi.metadata().await });
+        let result = py.detach(|| self.rt.block_on(async { self.qrmi.metadata().await }));
         Ok(result)
     }
 }
@@ -364,11 +369,16 @@ impl PyResourceProvider {
     /// resources = provider.resources("num_qubits=127&name=ibm_*")
     /// ```
     #[pyo3(signature = (filters=None))]
-    pub fn resources(&self, filters: Option<&str>) -> PyResult<Vec<PyQuantumResource>> {
+    pub fn resources(
+        &self,
+        py: Python<'_>,
+        filters: Option<&str>,
+    ) -> PyResult<Vec<PyQuantumResource>> {
         crate::common::initialize();
-        let result = self
-            .rt
-            .block_on(async { self.inner.resources(filters.map(str::to_string)).await });
+        let result = py.detach(|| {
+            self.rt
+                .block_on(async { self.inner.resources(filters.map(str::to_string)).await })
+        });
         match result {
             Ok(resources) => Ok(resources
                 .into_iter()
@@ -389,11 +399,16 @@ impl PyResourceProvider {
     /// resource = provider.least_busy("num_qubits=127&status=online")
     /// ```
     #[pyo3(signature = (filters=None))]
-    pub fn least_busy(&self, filters: Option<&str>) -> PyResult<Option<PyQuantumResource>> {
+    pub fn least_busy(
+        &self,
+        py: Python<'_>,
+        filters: Option<&str>,
+    ) -> PyResult<Option<PyQuantumResource>> {
         crate::common::initialize();
-        let result = self
-            .rt
-            .block_on(async { self.inner.least_busy(filters.map(str::to_string)).await });
+        let result = py.detach(|| {
+            self.rt
+                .block_on(async { self.inner.least_busy(filters.map(str::to_string)).await })
+        });
         match result {
             Ok(resource) => Ok(resource.map(PyQuantumResource::from_inner)),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
@@ -451,9 +466,110 @@ impl PyConfig {
     }
 }
 
+/// Bridges QRMI's `log` records into Python's `logging` module.
+///
+/// Registered once via `crate::common::set_log_sink` from the
+/// `#[pymodule]` init function below, using the same `LogSink` extension
+/// point `cext::qrmi_log_callback_set` also adapts a C callback into,
+/// rather than installing a second, separate logging backend. This avoids
+/// ever having two loggers registered in the same process (the `log`
+/// crate only allows one), which matters because `cext` is always
+/// compiled in alongside `pyext` when the `pyo3` feature is enabled.
+///
+/// The `env_logger` filter in `common::initialize` (default `RUST_LOG`
+/// level: `warn`) still runs first and decides what reaches this sink at
+/// all; what changes here is only where an accepted record goes
+/// afterwards. A record that passes that filter is forwarded to
+/// `logging.getLogger(target)`, so Python-side configuration
+/// (`logging.basicConfig()`, per-logger levels, handlers) governs it from
+/// there same as any other Python log record.
+///
+/// This is a plain Rust closure over `common::LogSink` -- no C ABI, no raw
+/// pointers, no `unsafe`. `common.rs` doesn't know or care that this
+/// particular sink happens to call into Python; that's this module's
+/// business alone. Compare `cext::qrmi_log_callback_set`, which adapts a
+/// C function pointer into the same `LogSink` shape at its own boundary.
+fn python_log_sink(level: log::Level, target: &str, message: &str) {
+    // Python's `logging` module level numbers (see Python's `logging`
+    // module docs / `Lib/logging/__init__.py`: CRITICAL=50, ERROR=40,
+    // WARNING=30, INFO=20, DEBUG=10, NOTSET=0). Hardcoded rather than
+    // looked up via `logging.ERROR` etc. because these values are part of
+    // `logging`'s documented, long-stable public API and are very unlikely
+    // to change.
+    // TRACE has no Python equivalent, so it is folded into DEBUG.
+    let py_level: i32 = match level {
+        log::Level::Error => 40,
+        log::Level::Warn => 30,
+        log::Level::Info => 20,
+        log::Level::Debug | log::Level::Trace => 10,
+    };
+
+    Python::attach(|py| {
+        let Ok(logging) = py.import("logging") else {
+            return;
+        };
+        let Ok(logger) = logging.call_method1("getLogger", (target,)) else {
+            return;
+        };
+        let _ = logger.call_method1("log", (py_level, message));
+    });
+}
+
+/// Registers a user-supplied Python callable as the destination for
+/// QRMI's `log` records, replacing whatever sink is currently active --
+/// including the default one installed at import time (see
+/// `python_log_sink` above). This is the Python-facing equivalent of the
+/// C API's `qrmi_log_callback_set`.
+///
+/// `callback` is called as `callback(level, target, message)`, all three
+/// arguments `str`. `level` is one of `"ERROR"`, `"WARN"`, `"INFO"`,
+/// `"DEBUG"`, `"TRACE"`. Pass `None` to clear it, which reverts to plain
+/// stderr output -- the same fallback the C API's `NULL` reverts to --
+/// rather than back to the built-in `logging`-forwarding sink. Once you
+/// take over logging, where it goes (including back to `logging`, if
+/// that's what you want) is entirely your callback's responsibility.
+///
+/// # Notes
+///
+/// - `callback` may run on any thread, including a tokio worker thread
+///   unrelated to whichever Python thread called into QRMI. This is safe
+///   as long as every blocking QRMI call keeps releasing the GIL for its
+///   duration (see the `py.detach(...)` calls throughout this module) --
+///   that is what lets a worker thread acquire the GIL here without
+///   deadlocking against a QRMI call that is still holding it.
+/// - `callback` runs synchronously and holds the GIL while it runs; a slow
+///   callback delays whichever QRMI call happened to trigger the log
+///   record it's handling. Keep it fast -- e.g. hand off to a queue --
+///   if you need to do anything slow with a record.
+/// - If `callback` raises, the exception is printed (as an unhandled
+///   exception would be) and otherwise discarded; it cannot propagate
+///   back into the Rust code that logged in the first place.
+#[gen_stub_pyfunction]
+#[pyfunction]
+fn set_log_callback(callback: Option<Py<PyAny>>) -> PyResult<()> {
+    crate::common::initialize();
+    let sink: Option<crate::common::LogSink> = callback.map(|callback| {
+        let sink: crate::common::LogSink =
+            std::sync::Arc::new(move |level: log::Level, target: &str, message: &str| {
+                Python::attach(|py| {
+                    if let Err(err) = callback.call1(py, (level.as_str(), target, message)) {
+                        err.print(py);
+                    }
+                });
+            });
+        sink
+    });
+    crate::common::set_log_sink(sink)
+        .map_err(|()| pyo3::exceptions::PyRuntimeError::new_err("Failed to set log callback"))
+}
+
 /// A Python module implemented in Rust.
 #[pymodule(name = "_core")]
 fn qrmi(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    crate::common::initialize();
+    let _ = crate::common::set_log_sink(Some(std::sync::Arc::new(python_log_sink)));
+
+    m.add_function(wrap_pyfunction!(set_log_callback, m)?)?;
     m.add_class::<PyQuantumResource>()?;
     m.add_class::<ResourceType>()?;
     m.add_class::<crate::models::TaskStatus>()?;


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
### Summary

QRMI's Python extension (`pyext.rs`) registers a callback with the shared `log`-crate sink (`common.rs`) so that `log::error!()` and friends — previously visible only on the C/CLI path — now reach Python's `logging` module by default, and can be redirected to a user-supplied Python callable via a new `qrmi.set_log_callback()` function. Along the way this also fixes a real deadlock that the naive version of this change introduced, and refactors `common.rs` so it no longer forces a C ABI shape onto its pure-Rust consumer.

No public C API behavior changes. `qrmi_log_callback_set()`'s contract (NULL semantics, string arguments, in-flight-call caveat) is unchanged.

### Motivation

Previously, `log::error!()` records produced by this crate (e.g. inside `target()`, `is_accessible()`) were only visible when QRMI was used from the CLI/examples or from C, via `env_logger`'s stderr output. When used as a Python library — the primary way most users consume QRMI — no logging backend was ever registered, so these records were silently dropped. This made real failures (backend errors, malformed responses) invisible unless they also happened to surface as a raised exception at the same call site.

### Changes

#### 1. `common.rs`: made the shared log sink Rust-native

`common.rs` previously defined the single registration point for "where do log records go" (`LOG_CALLBACK` / `QrmiLogCallback`) as a C ABI type (`unsafe extern "C" fn(*const c_char, ...)`), because that was the only
shape `cext.rs`'s C-facing API could hand it. `pyext.rs` had no need for that shape at all, but had to conform to it anyway, round-tripping every record through `CString`/`CStr` for no reason.

`common.rs` now exposes a plain Rust type instead:

```rust
pub(crate) type LogSink = Arc<dyn Fn(log::Level, &str, &str) + Send + Sync>;
pub(crate) fn set_log_sink(sink: Option<LogSink>) -> Result<(), ()>;
```

`cext.rs` and `pyext.rs` each register their own adapter against this one Rust-native type; the C ABI shape now lives only in `cext.rs`, where it's actually needed.

`LogSink` is `Arc`, not `Box`: `dispatch_to_sink` clones the handle and releases `LOG_SINK`'s `RwLock` *before* invoking it, rather than holding the lock for the call's duration. This matters once a sink can run arbitrary, possibly slow, possibly re-entrant code (a user's Python callback in particular) — `std::sync::RwLock` does not guarantee safe
recursive read-locking, so holding it across such a call would risk a deadlock or worse. (The previous C-function-pointer design didn't have this problem, because a `Copy` function pointer could be read out of the lock and the lock dropped immediately; a boxed closure can't be copied out that way.)

#### 2. `cext.rs`: `QrmiLogCallback` moved here, C string handling stays here

`QrmiLogCallback` (the C function pointer type) and the `CString` sanitization helper (`sanitized_cstring`, stripping embedded NULs before building a `CString`) now live in `cext.rs` instead of `common.rs`. `qrmi_log_callback_set()` builds a small adapter closure around the caller's C function pointer, doing the `CString` conversion only when a
record actually needs to reach it, and registers that adapter as a `LogSink`. The function's public behavior and safety contract are unchanged.

#### 3. `pyext.rs`: default logging bridge + user-overridable callback

- A default sink (`python_log_sink`) is registered when the `_core` module is imported. It forwards each record to
  `logging.getLogger(target).log(level, message)`, so standard Python logging configuration (`logging.basicConfig()`, per-logger levels, handlers) governs QRMI's Rust-side log output the same way it governs any other Python log record. No action needed from users who just want
  logging to work.
- A new function, `qrmi.set_log_callback(callback)`, lets a user register their own `callback(level: str, target: str, message: str)` in place of the default, mirroring the C API's `qrmi_log_callback_set()`. Passing `None` clears it, reverting to plain stderr (the same fallback `NULL` triggers on the C side) rather than back to the `logging`-forwarding default — once a caller takes over, where records go is entirely their callback's responsibility. If the callback raises, the exception is printed (as an unhandled exception would be) and discarded; it cannot propagate back into the Rust call site that produced the log record.
- Rust's `RUST_LOG` filter (default `warn`) still runs before any sink is invoked, Python or C, and currently cannot be changed from the Python side; only records that pass it reach `logging` (or a user callback) at all. This is a known, separate limitation, not addressed by this PR.
- Python code inside this package that calls `logging.getLogger("qrmi")` directly (e.g. `python/qrmi/primitives/service.py`) is unaffected by any of this — those records never go through the Rust `log` crate or `LogSink` in the first place, so `set_log_callback()` has no effect on them.

#### 4. Deadlock fix: release the GIL around every blocking call

While testing the above with `RUST_LOG=trace`, we hit a real deadlock: `PyQuantumResource`'s methods call `self.rt.block_on(...)` on a multi-threaded tokio `Runtime` while still holding the GIL (standard for a
`#[pymethods]` call). At `trace` level, `reqwest`/`hyper` log frequently enough that some record is virtually guaranteed to be emitted from a tokio worker thread. That worker thread then needs the GIL to reach `python_log_sink`/a user callback — but the GIL is held by the main thread, which is itself blocked inside `block_on` waiting on that same worker thread. Both sides wait forever.

Fixed by wrapping every `self.rt.block_on(...)` call (14 call sites across `PyQuantumResource` and `PyResourceProvider`) in `py.detach(|| ...)`,  releasing the GIL for the duration of the blocking wait — the documented
pattern for this exact situation (see `Python::detach`'s own docs, which name "awaiting a future" as a case to release the GIL for). This was verifiable only by actually building and running with `RUST_LOG=trace`; it would not have been caught by `warn`-level testing, since error/warn records are rare enough that the race window is unlikely to be hit.

### Testing

- Built and run manually against live IBM Qiskit Runtime Service backends   (`examples/qiskit_primitives/ibm/sampler.py`), confirming:
  - Default behavior: `logging.basicConfig(level=logging.ERROR, ...)` in the calling script now shows QRMI's Rust-side `error!()` records with the expected target (`qrmi::ibm::qiskit_runtime_service`) and message.
  - `RUST_LOG=trace` no longer hangs (previously deadlocked before the `py.detach()` fix).
  - A custom callback registered via `qrmi.set_log_callback()` receives Rust-side records instead of the default `logging` forwarding, and Python-native `qrmi` package logging (`primitives/service.py` etc.) is unaffected either way, as expected.
  
- Test with [Spank plugins (C API)  PR](https://github.com/qiskit-community/spank-plugins/pull/196)

### Backward compatibility

- **C API**: no change. `qrmi_log_callback_set()` keeps the same signature, NULL semantics, and in-flight-call caveat.
- **Python API**: additive only. Existing code that does nothing keeps getting the same behavior as before, except that `error!()`-level records are now actually visible (previously silent) via standard `logging` configuration. `qrmi.set_log_callback()` is a new, optional function.
- **Rust internals**: `common::QrmiLogCallback` and `common::set_log_callback()` no longer exist; both moved to `cext.rs` (renamed `set_log_sink`/`LogSink` at the `common.rs` level). This only affects code inside this crate — `cext.rs` and `pyext.rs` were the only callers, and both are updated in this PR.

### Limitations

- `RUST_LOG`'s level filter is still separate from Python's per-logger levels; a Python user cannot currently raise the Rust-side filter above `warn` without setting the environment variable before the process starts. Worth a follow-up if `DEBUG`/`TRACE` visibility from pure Python is wanted.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
