### PR TITLE
bugfix: `connection_verbose(true)` removed from release builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,14 @@ is the property of your employer, then you will more than likely need to sign a
 [corporate CLA](https://qisk.it/corporate-cla) too and
 email it to us at <qiskit@us.ibm.com>.
 
+## Debug builds
+
+All `make build*`/`lint*`/`test*` targets build in release mode by default.
+Pass `DEBUG=1` (e.g. `DEBUG=1 make build`) to build in debug mode instead.
+See `make help` for details.
+
+For the python build process, run `maturin build` without the `--release` flag instead.
+
 ## Testing
 
 Once you've made a code change, it is important to verify that your change
@@ -265,10 +273,6 @@ documentation's [guide on writing tests](https://doc.rust-lang.org/book/ch11-01-
 For executing the tests with the makefile, a `make test` target is available.
 The execution of the tests (both via the make target and during manual
 invocation) takes into account the `LOG_LEVEL` environment variable.
-
-All `make build*`/`lint*`/`test*` targets build in release mode by default.
-Pass `DEBUG=1` (e.g. `DEBUG=1 make build`) to build in debug mode instead.
-See `make help` for details.
 
 
 ### Unsafe code and Miri

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,10 @@ For executing the tests with the makefile, a `make test` target is available.
 The execution of the tests (both via the make target and during manual
 invocation) takes into account the `LOG_LEVEL` environment variable.
 
+All `make build*`/`lint*`/`test*` targets build in release mode by default.
+Pass `DEBUG=1` (e.g. `DEBUG=1 make build`) to build in debug mode instead.
+See `make help` for details.
+
 
 ### Unsafe code and Miri
 

--- a/Makefile
+++ b/Makefile
@@ -15,39 +15,39 @@ include Makefile_common.mk
 .PHONY: build build-rust-examples build-task-runner build-stubgen
 .PHONY: build-c-examples build-wheels build-rust-all
 
-LIBQRMI_SO_PATH : build
+$(LIBQRMI_SO_PATH): build
 
 build:
-	cargo build --locked --release --lib
+	cargo build --locked $(CARGO_PROFILE_FLAG) --lib
 
 build-rust-examples:
-	cargo build --locked --release --examples
+	cargo build --locked $(CARGO_PROFILE_FLAG) --examples
 
 build-task-runner:
-	cargo build --locked --release --bin task_runner --features="build-binary"
+	cargo build --locked $(CARGO_PROFILE_FLAG) --bin task_runner --features="build-binary"
 
 build-stubgen: check-python-devel-installed
 ifeq ($(INSIDE_CONTAINER),1)
 	$(error "Manylinux images don't come with libpython, please run the command without ./run_in_container.sh")
 endif
-	PYO3_PYTHON=python$(PYTHON_VERSION) cargo build --locked --release --bin stubgen --features="pyo3"
+	PYO3_PYTHON=python$(PYTHON_VERSION) cargo build --locked $(CARGO_PROFILE_FLAG) --bin stubgen --features="pyo3"
 
 build-c-examples: $(LIBQRMI_SO_PATH)
 	@mkdir -p examples/qrmi/c/ibm_quantum_system/build
 	@cd examples/qrmi/c/ibm_quantum_system/build && \
-		cmake -DCMAKE_BUILD_TYPE=Release .. && \
+		cmake -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) .. && \
 		cmake --build .
 	@mkdir -p examples/qrmi/c/qiskit_runtime_service/build
 	@cd examples/qrmi/c/qiskit_runtime_service/build && \
-		cmake -DCMAKE_BUILD_TYPE=Release .. && \
+		cmake -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) .. && \
 		cmake --build .
 	@mkdir -p examples/qrmi/c/pasqal_cloud/build
 	@cd examples/qrmi/c/pasqal_cloud/build && \
-		cmake -DCMAKE_BUILD_TYPE=Release .. && \
+		cmake -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) .. && \
 		cmake --build .
 	@mkdir -p examples/qrmi/c/config/build
 	@cd examples/qrmi/c/config/build && \
-		cmake -DCMAKE_BUILD_TYPE=Release .. && \
+		cmake -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) .. && \
 		cmake --build .
 
 $(WHEELS_PATH):
@@ -67,19 +67,19 @@ build-rust-all: build build-rust-examples build-task-runner
 .PHONY: lint-wheels lint-rust-all
 
 lint:
-	cargo clippy --locked --release --lib -- -D warnings
+	cargo clippy --locked $(CARGO_PROFILE_FLAG) --lib -- -D warnings
 
 lint-rust-examples:
-	cargo clippy --locked --release --examples -- -D warnings
+	cargo clippy --locked $(CARGO_PROFILE_FLAG) --examples -- -D warnings
 
 lint-task-runner:
-	cargo clippy --locked --release --bin task_runner --features="build-binary" -- -D warnings
+	cargo clippy --locked $(CARGO_PROFILE_FLAG) --bin task_runner --features="build-binary" -- -D warnings
 
 lint-stubgen: check-python-devel-installed
 ifeq ($(INSIDE_CONTAINER),1)
 	$(error "Manylinux images don't come with libpython, please run the command without ./run_in_container.sh")
 endif
-	PYO3_PYTHON=python$(PYTHON_VERSION) cargo clippy --locked --release --bin stubgen --features="pyo3" -- -D warnings
+	PYO3_PYTHON=python$(PYTHON_VERSION) cargo clippy --locked $(CARGO_PROFILE_FLAG) --bin stubgen --features="pyo3" -- -D warnings
 
 lint-wheels: $(PYTHON_VENV_DIR) install-wheels
 	@source $(PYTHON_VENV_ACTIVATE) && \
@@ -96,27 +96,27 @@ lint-rust-all: lint lint-rust-examples lint-task-runner
 .PHONY: test-stubgen test-wheels test-rust-all
 
 test:
-	cargo test --lib --locked --release
+	cargo test --lib --locked $(CARGO_PROFILE_FLAG)
 
 test-doc:
-	cargo test --doc --locked --release
+	cargo test --doc --locked $(CARGO_PROFILE_FLAG)
 
 test-deps:
-	cargo test --locked --release -p quantum-system-api
-	cargo test --locked --release -p pasqal-cloud-api
-	cargo test --locked --release -p qiskit_runtime_client
+	cargo test --locked $(CARGO_PROFILE_FLAG) -p quantum-system-api
+	cargo test --locked $(CARGO_PROFILE_FLAG) -p pasqal-cloud-api
+	cargo test --locked $(CARGO_PROFILE_FLAG) -p qiskit_runtime_client
 
 test-rust-examples:
-	cargo test --examples --locked --release
+	cargo test --examples --locked $(CARGO_PROFILE_FLAG)
 
 test-task-runner:
-	cargo test --locked --release --bin task_runner --features="build-binary"
+	cargo test --locked $(CARGO_PROFILE_FLAG) --bin task_runner --features="build-binary"
 
 test-stubgen: check-python-devel-installed
 ifeq ($(INSIDE_CONTAINER),1)
 	$(error "Manylinux images don't come with libpython, please run the command without ./run_in_container.sh")
 endif
-	PYO3_PYTHON=python$(PYTHON_VERSION) cargo test --locked --release --bin stubgen --features="pyo3"
+	PYO3_PYTHON=python$(PYTHON_VERSION) cargo test --locked $(CARGO_PROFILE_FLAG) --bin stubgen --features="pyo3"
 
 test-wheels: $(PYTHON_VENV_DIR)
 	@source $(PYTHON_VENV_ACTIVATE) && \
@@ -225,7 +225,7 @@ vendor-tarball:
 	@echo
 	@echo "Created: $(DIST_DIR)/qrmi-$(QRMI_VERSION)-vendor.tar.gz"
 
-libqrmi-tarball: LIBQRMI_SO_PATH
+libqrmi-tarball: $(LIBQRMI_SO_PATH)
 	@TARBALL="$(DIST_DIR)/libqrmi-$(QRMI_VERSION)-el8-$(ARCH).tar.gz" && \
 	WORKDIR="$(DIST_DIR)/libqrmi-$(QRMI_VERSION)" && \
 	mkdir -p $$WORKDIR && \
@@ -346,6 +346,9 @@ $$ source $$(make get-venv-activate)
 
 Create a venv for a custom python version.
 $$ PYTHON_VERSION=3.13 make create-venv
+
+Build libqrmi.so, qrmi.h and examples, task_runner, etc. in debug mode instead of release.
+$$ DEBUG=1 make build
 
 Activate a customized venv created by the makefile.
 $$ source $$(PYTHON=3.12 make get-venv-activate)

--- a/Makefile_common.mk
+++ b/Makefile_common.mk
@@ -19,8 +19,20 @@ PYTHON_VENV_ACTIVATE = $(PYTHON_VENV_DIR)/bin/activate
 
 WHEELS_PATH = wheelhouse/qrmi-$(QRMI_VERSION)-cp$(PYTHON_VERSION_NO_DOTS)-abi3-$(MANYLINUX_VERSION)_$(ARCH).whl
 
-LIBQRMI_SO_PATH = target/release/libqrmi.so
 QRMI_H_PATH = qrmi.h
+
+DEBUG ?= 0
+ifeq ($(DEBUG),1)
+CARGO_PROFILE_FLAG =
+CARGO_PROFILE_DIR = debug
+CMAKE_BUILD_TYPE = Debug
+else
+CARGO_PROFILE_FLAG = --release
+CARGO_PROFILE_DIR = release
+CMAKE_BUILD_TYPE = Release
+endif
+
+LIBQRMI_SO_PATH = target/$(CARGO_PROFILE_DIR)/libqrmi.so
 
 ifeq ($(INSIDE_CONTAINER),1)
 CONTAINER_ENGINE = inside_container

--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -187,7 +187,9 @@ impl Client {
 impl Client {
     fn build_http_client() -> Result<reqwest_middleware::ClientWithMiddleware> {
         let mut reqwest_client_builder = reqwest::Client::builder();
-        reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
+        if cfg!(debug_assertions) {
+            reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
+        }
         let reqwest_builder = ReqwestClientBuilder::new(reqwest_client_builder.build()?);
         Ok(reqwest_builder.build())
     }

--- a/dependencies/pasqal_cloud_client/src/client.rs
+++ b/dependencies/pasqal_cloud_client/src/client.rs
@@ -238,7 +238,6 @@ impl Client {
     async fn handle_request<T: DeserializeOwned>(&self, resp: reqwest::Response) -> Result<T> {
         if resp.status().is_success() {
             let json_text = resp.text().await?;
-            debug!("{}", json_text);
             let val = serde_json::from_str(&json_text)?;
             Ok(val)
         } else {

--- a/dependencies/pasqal_local_client/src/client.rs
+++ b/dependencies/pasqal_local_client/src/client.rs
@@ -16,7 +16,6 @@ use crate::munge;
 use anyhow::{bail, Result};
 
 use crate::models::job::JobStatus;
-use log::debug;
 use reqwest::header;
 use reqwest_middleware::ClientBuilder as ReqwestClientBuilder;
 use serde::de::DeserializeOwned;
@@ -220,7 +219,6 @@ impl Client {
     async fn handle_request<T: DeserializeOwned>(&self, resp: reqwest::Response) -> Result<T> {
         if resp.status().is_success() {
             let json_text = resp.text().await?;
-            debug!("{}", json_text);
             let val = serde_json::from_str(&json_text)?;
             Ok(val)
         } else {

--- a/dependencies/pasqal_local_client/src/client.rs
+++ b/dependencies/pasqal_local_client/src/client.rs
@@ -265,8 +265,9 @@ impl ClientBuilder {
     /// ```
     pub fn build(&mut self) -> Result<Client> {
         let mut reqwest_client_builder = reqwest::Client::builder();
-        reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
-
+        if cfg!(debug_assertions) {
+            reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
+        }
         let reqwest_builder = ReqwestClientBuilder::new(reqwest_client_builder.build()?);
 
         Ok(Client {

--- a/dependencies/qiskit_runtime_client/src/apis/configuration.rs
+++ b/dependencies/qiskit_runtime_client/src/apis/configuration.rs
@@ -36,12 +36,13 @@ impl Configuration {
 
 impl Default for Configuration {
     fn default() -> Self {
-        let client = reqwest::Client::builder()
+        let mut client_builder = reqwest::Client::builder();
+        if cfg!(debug_assertions) {
             // Enabling this option will emit log messages at the TRACE level for
             // read and write operations on connections.
-            .connection_verbose(true)
-            .build()
-            .unwrap();
+            client_builder = client_builder.connection_verbose(true)
+        }
+        let client = client_builder.build().unwrap();
 
         Configuration {
             base_path: "/api".to_owned(),

--- a/dependencies/quantum_system_client/src/client.rs
+++ b/dependencies/quantum_system_client/src/client.rs
@@ -476,8 +476,10 @@ impl ClientBuilder {
             }
         }
 
-        reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
-        reqwest_plain_client_builder = reqwest_plain_client_builder.connection_verbose(true);
+        if cfg!(debug_assertions) {
+            reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
+            reqwest_plain_client_builder = reqwest_plain_client_builder.connection_verbose(true);
+        }
         if let Some(v) = self.timeout {
             reqwest_client_builder = reqwest_client_builder.timeout(v);
             reqwest_plain_client_builder = reqwest_plain_client_builder.timeout(v)

--- a/dependencies/quantum_system_client/src/client.rs
+++ b/dependencies/quantum_system_client/src/client.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Result};
 use std::time::Duration;
 
 #[allow(unused_imports)]
-use log::{debug, error, info, warn};
+use log::{error, info, warn};
 use reqwest::header;
 use reqwest_middleware::ClientBuilder as ReqwestClientBuilder;
 use reqwest_retry::policies::ExponentialBackoff;
@@ -134,7 +134,6 @@ impl Client {
                 let status = resp.status();
                 if status.is_success() {
                     let json_text = resp.text().await?;
-                    debug!("{}", json_text);
                     Ok(serde_json::from_str::<T>(&json_text)?)
                 } else {
                     match resp.json::<ExtendedErrorResponse>().await {

--- a/dependencies/quantum_system_client/src/middleware/auth.rs
+++ b/dependencies/quantum_system_client/src/middleware/auth.rs
@@ -208,7 +208,6 @@ impl Middleware for AuthMiddleware {
         let token = token_manager.get_token().await?;
         // add authentication header to the request
         let mut cloned_req = request.try_clone().unwrap();
-        debug!("current token {}", token);
         cloned_req.headers_mut().insert(
             reqwest::header::AUTHORIZATION,
             format!("Bearer {}", token).parse().unwrap(),
@@ -227,7 +226,6 @@ impl Middleware for AuthMiddleware {
             debug!("renew access token");
             token_manager.get_access_token().await?;
             let token = token_manager.get_token().await?;
-            debug!("new token {}", token);
             let mut new_request = request.try_clone().unwrap();
             new_request.headers_mut().insert(
                 reqwest::header::AUTHORIZATION,

--- a/dependencies/quantum_system_client/src/middleware/auth.rs
+++ b/dependencies/quantum_system_client/src/middleware/auth.rs
@@ -51,7 +51,9 @@ impl TokenManager {
         retry_policy: Option<reqwest_retry::policies::ExponentialBackoff>,
     ) -> Result<Self> {
         let mut reqwest_client_builder = reqwest::Client::builder();
-        reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
+        if cfg!(debug_assertions) {
+            reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
+        }
         if let Some(v) = timeout {
             reqwest_client_builder = reqwest_client_builder.timeout(v)
         }


### PR DESCRIPTION
## Description of Change

Removed `connection_verbose(true)` from `reqwest` client builder in dependencies. This option could leak  authorisation bearing headers when setting `RUST_LOGS=trace`. 

Additional leaky `debug!` statements removed.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [x] Fixes #189 
- [ ] Is Part of #
