### PR TITLE
feat: add get_version() to the API

### DIFF
--- a/src/cext.rs
+++ b/src/cext.rs
@@ -261,6 +261,29 @@ pub unsafe extern "C" fn qrmi_log_callback_set(callback: QrmiLogCallback) -> Ret
 }
 
 /// @ingroup Qrmi
+/// Returns the version of this QRMI library as a semantic version string.
+///
+/// Callers can compare this against the version they were built against to detect
+/// incompatibilities at runtime, for example after a system upgrade replaced the
+/// shared library underneath them.
+///
+/// The returned pointer refers to a string with static lifetime owned by the
+/// library. It must NOT be passed to `qrmi_string_free()`.
+///
+/// # Example
+///
+/// @code
+///   printf("QRMI version = %s\n", qrmi_get_version());
+/// @endcode
+///
+/// @return pointer to a NUL-terminated version string such as "0.22.0". Never NULL.
+/// @version 0.23.0
+#[no_mangle]
+pub extern "C" fn qrmi_get_version() -> *const c_char {
+    concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr() as *const c_char
+}
+
+/// @ingroup Qrmi
 /// Free a string allocated by C API
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,25 @@ use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use anyhow::Result;
 use async_trait::async_trait;
 
+/// Version of this QRMI library, as a semantic version string such as `"0.22.0"`.
+///
+/// Callers can compare this against the version they were built against to detect
+/// incompatibilities at runtime, for example after a system upgrade replaced the
+/// shared library underneath them.
+///
+/// Note that versions below `1.0.0` are considered unstable, so a mismatch in the
+/// minor component is enough to signal a potentially breaking change.
+///
+/// # Example
+///
+/// ```
+/// let version = qrmi::get_version();
+/// println!("{version}"); // prints e.g. "0.22.0"
+/// ```
+pub fn get_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
 /// Defines interfaces to quantum resources.
 #[async_trait]
 pub trait QuantumResource: Send + Sync {

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -619,6 +619,17 @@ fn set_log_callback(callback: Option<Py<PyAny>>) -> PyResult<()> {
         .map_err(|()| pyo3::exceptions::PyRuntimeError::new_err("Failed to set log callback"))
 }
 
+/// Returns the version of this QRMI library as a semantic version string.
+///
+/// Callers can compare this against the version they were built against to detect
+/// incompatibilities at runtime, for example after a system upgrade replaced the
+/// native extension underneath them.
+#[gen_stub_pyfunction]
+#[pyfunction]
+fn get_version() -> &'static str {
+    crate::get_version()
+}
+
 /// A Python module implemented in Rust.
 #[pymodule(name = "_core")]
 fn qrmi(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -626,6 +637,7 @@ fn qrmi(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let _ = crate::common::set_log_sink(Some(std::sync::Arc::new(python_log_sink)));
 
     m.add_function(wrap_pyfunction!(set_log_callback, m)?)?;
+    m.add_function(wrap_pyfunction!(get_version, m)?)?;
     m.add_class::<PyQuantumResource>()?;
     m.add_class::<ResourceType>()?;
     m.add_class::<crate::models::TaskStatus>()?;


### PR DESCRIPTION
Exposes the library version at runtime so callers can detect an incompatible `libqrmi` after a system upgrade or downgrade, as described in the issue.

The version comes from `env!("CARGO_PKG_VERSION")`, so it is baked in at compile time from `Cargo.toml` and cannot drift from the published package version.

### Three surfaces

| Surface | Signature |
|---|---|
| Rust | `qrmi::get_version() -> &'static str` |
| C | `const char *qrmi_get_version(void)` |
| Python | `qrmi.get_version() -> str` |

The C function returns a pointer to a static NUL-terminated string built with `concat!(env!("CARGO_PKG_VERSION"), "\0")`. It never allocates and never returns NULL, so there is nothing for the caller to free — the doc comment says so explicitly, since every other string-returning C function here does require `qrmi_string_free()` and I did not want that asymmetry to be a surprise.

The Python function is registered on the `_core` module and reaches users through the existing `from ._core import *` in `python/qrmi/__init__.py`, so no extra plumbing was needed.

### Verification

- `cargo build --lib` — clean
- `cargo check --lib --features pyo3` — clean
- `cargo clippy --lib` — no new warnings
- `cargo test --doc get_version` — the doctest on the Rust function passes
- cbindgen emits `const char *qrmi_get_version(void);` into the generated `qrmi.h` as expected

### One thing to confirm

I tagged the C function `@version 0.23.0`, guessing the next minor after the current `0.22.0`. Happy to change it if the release it lands in ends up being different.

As #168 notes, compatibility checks only really become meaningful once the API reaches 1.0 — this just puts the primitive in place so callers can start relying on it.

Closes #196