### PR TITLE
Fix inconsistent setting of cargo in rust examples

### DIFF
--- a/examples/qrmi/rust/alice_bob_felis/Cargo.toml
+++ b/examples/qrmi/rust/alice_bob_felis/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]

--- a/examples/qrmi/rust/ibm_quantum_compute_service/Cargo.toml
+++ b/examples/qrmi/rust/ibm_quantum_compute_service/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "qrmi-example-ibm-quantum-compute-service"
 version = "0.1.0"
-edition = "2026"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]

--- a/examples/qrmi/rust/ibm_quantum_system/Cargo.toml
+++ b/examples/qrmi/rust/ibm_quantum_system/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]

--- a/examples/qrmi/rust/iqm_server/Cargo.toml
+++ b/examples/qrmi/rust/iqm_server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]

--- a/examples/qrmi/rust/pasqal_cloud/Cargo.toml
+++ b/examples/qrmi/rust/pasqal_cloud/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]

--- a/examples/qrmi/rust/pasqal_local/Cargo.toml
+++ b/examples/qrmi/rust/pasqal_local/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]

--- a/examples/qrmi/rust/qrmi_config/Cargo.toml
+++ b/examples/qrmi/rust/qrmi_config/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]

--- a/examples/qrmi/rust/resource_providers/Cargo.toml
+++ b/examples/qrmi/rust/resource_providers/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/qiskit-community/qrmi"
-rust-version = "1.86" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
+rust-version = "1.91" # Keep in sync with docs/client/*.md and rust-toolchain.toml.
 
 
 [dependencies]


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
This PR fixes inconsistent parameter in Cargo.toml across the rust examples.
- quantum_compute_service
   - edition should be 2021.
- all
   - rust-version should be 1.91

@yoonho @awennersteen @MatthieuMoreau0 @OkuyanBoga You don't need to review this. This is simple library maintenance, which is required to fix some security issues reported by Github.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
