### PR TITLE
Remove deprecated pyo3 option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -142,7 +142,7 @@ Build the python wheels:
 
 ```shell-session
 source ~/py312_qrmi_venv/bin/activate
-CARGO_TARGET_DIR=./target/release/maturin maturin build --release --features pyo3/extension-module,munge,pyo3/abi3,qrmi/pyo3
+CARGO_TARGET_DIR=./target/release/maturin maturin build --release --features munge,pyo3/abi3,qrmi/pyo3
 ```
 
 ## Other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.8,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -68,7 +68,7 @@ repository = "https://github.com/qiskit-community/qrmi"
 [tool.maturin]
 python-source = "python"
 module-name   = "qrmi._core" 
-features = ["pyo3/extension-module", "pyo3/abi3", "qrmi/pyo3"]
+features = ["pyo3/abi3", "qrmi/pyo3"]
 python-packages = [
     "qrmi",
 ]


### PR DESCRIPTION
## Description of Change

Update the python bindings build to remove deprecated pyo3 options (https://pyo3.rs/v0.29.2/features.html#extension-module) and bump maturin version in `pyproject.toml`.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
