### PR TITLE
Prevent qrmi_resource_release() from returning success on error

### DIFF
--- a/src/cext.rs
+++ b/src/cext.rs
@@ -1003,6 +1003,7 @@ pub unsafe extern "C" fn qrmi_resource_release(
             }
             Err(err) => {
                 _set_last_error(format!("{:?}", err));
+                return ReturnCode::Error;
             }
         }
     }


### PR DESCRIPTION
## Description of Change

`qrmi_resource_release()` is called to release an acquired resource, however, it is always returning success to the caller, even when there was an error.

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
