### PR TITLE
[IBM] quantum_system_client: replace anyhow with QuantumSystemError, fix retry-related bugs found along the way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,6 +2623,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
+ "retry-policies",
  "rhexdump",
  "serde",
  "serde_json",

--- a/dependencies/quantum_system_client/Cargo.toml
+++ b/dependencies/quantum_system_client/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = "0.1.83"
 http = "1.1.0"
 reqwest-middleware = { version = "0.4.2", features = ["json"] }
 reqwest-retry = "0.7.0"
+retry-policies = "0.4"
 tokio = { version = "1.40.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/dependencies/quantum_system_client/src/api/backend_config.rs
+++ b/dependencies/quantum_system_client/src/api/backend_config.rs
@@ -10,7 +10,7 @@
 // that they have been altered from the originals.
 
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -19,7 +19,6 @@ impl Client {
     /// # Example
     ///
     /// ```no_run
-    /// use anyhow::Result;
     /// use quantum_system_api::{AuthMethod, ClientBuilder};
     ///
     /// #[tokio::main]
@@ -53,6 +52,7 @@ impl Client {
             "{}/v1/backends/{}/configuration",
             self.base_url, backend_name
         );
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Backend)
+            .await
     }
 }

--- a/dependencies/quantum_system_client/src/api/backend_details.rs
+++ b/dependencies/quantum_system_client/src/api/backend_details.rs
@@ -10,7 +10,7 @@
 // that they have been altered from the originals.
 
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -46,6 +46,7 @@ impl Client {
     /// - specified backend is not found.
     pub async fn get_backend<T: DeserializeOwned>(&self, backend_name: &str) -> Result<T> {
         let url = format!("{}/v1/backends/{}", self.base_url, backend_name);
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Backend)
+            .await
     }
 }

--- a/dependencies/quantum_system_client/src/api/backend_lanes_config.rs
+++ b/dependencies/quantum_system_client/src/api/backend_lanes_config.rs
@@ -10,7 +10,7 @@
 // that they have been altered from the originals.
 
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -49,6 +49,7 @@ impl Client {
         backend_name: &str,
     ) -> Result<T> {
         let url = format!("{}/v1/backends/{}/lanes", self.base_url, backend_name);
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Backend)
+            .await
     }
 }

--- a/dependencies/quantum_system_client/src/api/backend_props.rs
+++ b/dependencies/quantum_system_client/src/api/backend_props.rs
@@ -10,7 +10,7 @@
 // that they have been altered from the originals.
 
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -49,6 +49,7 @@ impl Client {
         backend_name: &str,
     ) -> Result<T> {
         let url = format!("{}/v1/backends/{}/properties", self.base_url, backend_name);
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Backend)
+            .await
     }
 }

--- a/dependencies/quantum_system_client/src/api/backend_pulse_defaults.rs
+++ b/dependencies/quantum_system_client/src/api/backend_pulse_defaults.rs
@@ -10,7 +10,7 @@
 // that they have been altered from the originals.
 
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -50,6 +50,7 @@ impl Client {
         backend_name: &str,
     ) -> Result<T> {
         let url = format!("{}/v1/backends/{}/defaults", self.base_url, backend_name);
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Backend)
+            .await
     }
 }

--- a/dependencies/quantum_system_client/src/api/cancel_job.rs
+++ b/dependencies/quantum_system_client/src/api/cancel_job.rs
@@ -9,11 +9,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::models::errors::ExtendedErrorResponse;
-use crate::{Client, PrimitiveJob};
-use anyhow::{bail, Result};
+use crate::error::QuantumSystemError;
+use crate::{Client, PrimitiveJob, Result};
 use http::StatusCode;
-use log::error;
 
 impl Client {
     /// Cancels the specified job if it has not yet terminated. Also deletes the job
@@ -61,39 +59,16 @@ impl Client {
                     }
                     self.delete_job(job_id).await
                 } else {
-                    match resp.json::<ExtendedErrorResponse>().await {
-                        Ok(ExtendedErrorResponse::Json(error)) => {
-                            let serialized = serde_json::to_value(&error).unwrap();
-                            error!("{}", &serialized);
-                            bail!(format!(
-                                "An error occurred while sending the job cancellation request to the API. {}",
-                                serialized
-                            ));
-                        }
-                        Ok(ExtendedErrorResponse::Text(message)) => {
-                            error!("{}", message);
-                            bail!(format!(
-                                "An error occurred while sending the job cancellation request to the API. {} ({})",
-                                status_code, message
-                            ));
-                        }
-                        Err(_) => {
-                            error!("{} {}", status_code, url);
-                            bail!(format!(
-                                "An error occurred while sending the job cancellation request to the API. {} {}",
-                                status_code, url
-                            ));
-                        }
-                    }
+                    Err(QuantumSystemError::from_response(
+                        status_code,
+                        resp,
+                        &url,
+                        crate::error::ResourceKind::Job,
+                    )
+                    .await)
                 }
             }
-            Err(e) => {
-                let err_msg = Client::explain_reqwest_middleware_error(&e);
-                bail!(format!(
-                    "An error occurred while sending the job cancellation request to the API. {}",
-                    err_msg
-                ));
-            }
+            Err(e) => Err(QuantumSystemError::from_middleware_error(&e)),
         }
     }
 }

--- a/dependencies/quantum_system_client/src/api/delete_job.rs
+++ b/dependencies/quantum_system_client/src/api/delete_job.rs
@@ -9,11 +9,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::models::errors::ExtendedErrorResponse;
-use crate::{Client, PrimitiveJob};
-use anyhow::{bail, Result};
+use crate::error::QuantumSystemError;
+use crate::{Client, PrimitiveJob, Result};
 use http::StatusCode;
-use log::error;
 
 impl Client {
     /// Delete the specified job if it has terminated.
@@ -56,39 +54,16 @@ impl Client {
                 if status_code == StatusCode::NO_CONTENT {
                     Ok(())
                 } else {
-                    match resp.json::<ExtendedErrorResponse>().await {
-                        Ok(ExtendedErrorResponse::Json(error)) => {
-                            let serialized = serde_json::to_value(&error).unwrap();
-                            error!("{}", &serialized);
-                            bail!(format!(
-                                "An error occurred while sending the request to delete the job to the API. {}",
-                                serialized
-                            ));
-                        }
-                        Ok(ExtendedErrorResponse::Text(message)) => {
-                            error!("{}", message);
-                            bail!(format!(
-                                "An error occurred while sending the request to delete the job to the API. {} ({})",
-                                status_code, message
-                            ));
-                        }
-                        Err(_) => {
-                            error!("{} {}", status_code, url);
-                            bail!(format!(
-                                "An error occurred while sending the request to delete the job to the API. {} {}",
-                                status_code, url
-                            ));
-                        }
-                    }
+                    Err(QuantumSystemError::from_response(
+                        status_code,
+                        resp,
+                        &url,
+                        crate::error::ResourceKind::Job,
+                    )
+                    .await)
                 }
             }
-            Err(e) => {
-                let err_msg = Client::explain_reqwest_middleware_error(&e);
-                bail!(format!(
-                    "An error occurred while sending the request to delete the job to the API. {}",
-                    err_msg
-                ));
-            }
+            Err(e) => Err(QuantumSystemError::from_middleware_error(&e)),
         }
     }
 }

--- a/dependencies/quantum_system_client/src/api/job_details.rs
+++ b/dependencies/quantum_system_client/src/api/job_details.rs
@@ -9,8 +9,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::Result;
 use crate::{Client, PrimitiveJob};
-use anyhow::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -46,7 +46,8 @@ impl Client {
     /// - specified job is not found.
     pub async fn get_job<T: DeserializeOwned>(&self, job_id: &str) -> Result<T> {
         let url = format!("{}/v1/jobs/{}", self.base_url, job_id);
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Job)
+            .await
     }
 }
 

--- a/dependencies/quantum_system_client/src/api/job_status.rs
+++ b/dependencies/quantum_system_client/src/api/job_status.rs
@@ -10,8 +10,8 @@
 // that they have been altered from the originals.
 
 use crate::models::jobs::{Job, JobStatus};
+use crate::Result;
 use crate::{Client, PrimitiveJob};
-use anyhow::Result;
 
 impl Client {
     /// Returns the current status of the specified job.

--- a/dependencies/quantum_system_client/src/api/job_wait_for_final_state.rs
+++ b/dependencies/quantum_system_client/src/api/job_wait_for_final_state.rs
@@ -9,9 +9,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::error::QuantumSystemError;
 use crate::models::jobs::{Job, JobStatus};
-use crate::{Client, PrimitiveJob};
-use anyhow::{bail, Result};
+use crate::{Client, PrimitiveJob, Result};
 use std::time::{Duration, Instant};
 
 impl Client {
@@ -59,7 +59,9 @@ impl Client {
                 let now = Instant::now();
                 let elapsed = now.duration_since(start_time);
                 if elapsed >= Duration::from_secs_f64(t) {
-                    bail!("timeout occurred while waiting for completion".to_string());
+                    return Err(QuantumSystemError::JobNotReady(
+                        "timeout occurred while waiting for completion".to_string(),
+                    ));
                 }
             }
 

--- a/dependencies/quantum_system_client/src/api/list_api_versions.rs
+++ b/dependencies/quantum_system_client/src/api/list_api_versions.rs
@@ -11,7 +11,7 @@
 
 use crate::models::versions::ListAPIVersions;
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 
 impl Client {
     /// Returns the list of supported API versions.
@@ -39,7 +39,7 @@ impl Client {
     pub async fn list_api_versions(&self) -> Result<Vec<String>> {
         let url = format!("{}/versions", self.base_url,);
         let json_data = self
-            .get::<ListAPIVersions>(&url, &self.plain_client)
+            .get::<ListAPIVersions>(&url, &self.plain_client, crate::error::ResourceKind::Other)
             .await?;
         Ok(json_data.versions.unwrap_or_default())
     }

--- a/dependencies/quantum_system_client/src/api/list_backends.rs
+++ b/dependencies/quantum_system_client/src/api/list_backends.rs
@@ -10,7 +10,7 @@
 // that they have been altered from the originals.
 
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -45,6 +45,7 @@ impl Client {
     /// - authentication failed.
     pub async fn list_backends<T: DeserializeOwned>(&self) -> Result<T> {
         let url = format!("{}/v1/backends", self.base_url);
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Other)
+            .await
     }
 }

--- a/dependencies/quantum_system_client/src/api/list_jobs.rs
+++ b/dependencies/quantum_system_client/src/api/list_jobs.rs
@@ -10,7 +10,7 @@
 // that they have been altered from the originals.
 
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 use serde::de::DeserializeOwned;
 
 impl Client {
@@ -45,6 +45,7 @@ impl Client {
     /// - authentication failed.
     pub async fn list_jobs<T: DeserializeOwned>(&self) -> Result<T> {
         let url = format!("{}/v1/jobs", self.base_url);
-        self.get::<T>(&url, &self.client).await
+        self.get::<T>(&url, &self.client, crate::error::ResourceKind::Other)
+            .await
     }
 }

--- a/dependencies/quantum_system_client/src/api/run_job.rs
+++ b/dependencies/quantum_system_client/src/api/run_job.rs
@@ -9,11 +9,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::models::errors::ExtendedErrorResponse;
-use crate::Client;
-use anyhow::{bail, Result};
+use crate::error::QuantumSystemError;
+use crate::{Client, Result};
 use http::StatusCode;
-use log::error;
 
 impl Client {
     /// Run a job. Refer Quantum System API specifications for more details of the payload format.
@@ -89,39 +87,16 @@ impl Client {
                 if status_code == StatusCode::NO_CONTENT {
                     Ok(payload["id"].as_str().unwrap().to_string())
                 } else {
-                    match resp.json::<ExtendedErrorResponse>().await {
-                        Ok(ExtendedErrorResponse::Json(error)) => {
-                            let serialized = serde_json::to_value(&error).unwrap();
-                            error!("{}", &serialized);
-                            bail!(format!(
-                                "An error occurred while sending the request to run the job to the API. {}",
-                                serialized
-                            ));
-                        }
-                        Ok(ExtendedErrorResponse::Text(message)) => {
-                            error!("{}", message);
-                            bail!(format!(
-                                "An error occurred while sending the request to run the job to the API. {} ({})",
-                                status_code, message
-                            ));
-                        }
-                        Err(_) => {
-                            error!("{} {}", status_code, url);
-                            bail!(format!(
-                                "An error occurred while sending the request to run the job to the API. {} {}",
-                                status_code, url
-                            ));
-                        }
-                    }
+                    Err(QuantumSystemError::from_response(
+                        status_code,
+                        resp,
+                        &url,
+                        crate::error::ResourceKind::Job,
+                    )
+                    .await)
                 }
             }
-            Err(e) => {
-                let err_msg = Client::explain_reqwest_middleware_error(&e);
-                bail!(format!(
-                    "An error occurred while sending the request to run the job to the API. {}",
-                    err_msg
-                ));
-            }
+            Err(e) => Err(QuantumSystemError::from_middleware_error(&e)),
         }
     }
 }

--- a/dependencies/quantum_system_client/src/api/run_primitive.rs
+++ b/dependencies/quantum_system_client/src/api/run_primitive.rs
@@ -9,12 +9,12 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::error::QuantumSystemError;
 use crate::Client;
-use anyhow::{bail, Context, Result};
+use crate::Result;
 use log::debug;
 use uuid::Uuid;
 
-use aws_sdk_s3::error::DisplayErrorContext;
 use serde::de::DeserializeOwned;
 
 use crate::models::jobs::{JobStatus, LogLevel, ProgramId};
@@ -95,9 +95,12 @@ impl Client {
         payload: &serde_json::Value,
         job_id: Option<String>,
     ) -> Result<PrimitiveJob> {
-        let s3_config = self.s3_config.clone().context(
-            "S3 bucket is not configured. Use ClientBuilder.with_s3_bucket() to use this function.",
-        )?;
+        let s3_config = self.s3_config.clone().ok_or_else(|| {
+            QuantumSystemError::Other {
+                message: "S3 bucket is not configured. Use ClientBuilder.with_s3_bucket() to use this function.".to_string(),
+                source: None,
+            }
+        })?;
 
         let s3_config_remote: aws_sdk_s3::Config;
         if let Some(v) = self.s3_config_for_qsapi.clone() {
@@ -128,9 +131,9 @@ impl Client {
         {
             Ok(val) => val,
             Err(err) => {
-                bail!(format!(
-                    "An error occurred during upload to S3: {}",
-                    DisplayErrorContext(&err)
+                return Err(QuantumSystemError::other(
+                    "failed to upload to S3",
+                    err.into_service_error(),
                 ));
             }
         };
@@ -251,9 +254,13 @@ impl PrimitiveJob {
     pub async fn get_result<T: DeserializeOwned>(&self) -> Result<T> {
         let status = self.get_status().await?;
         if JobStatus::Cancelled == status || JobStatus::Failed == status {
-            bail!("Result is not available since job was not succeeded.".to_string());
+            return Err(QuantumSystemError::JobNotReady(
+                "result is not available since job was not succeeded".to_string(),
+            ));
         } else if JobStatus::Running == status {
-            bail!("Result is not available until the job is completed.".to_string());
+            return Err(QuantumSystemError::JobNotReady(
+                "result is not available until the job is completed".to_string(),
+            ));
         }
 
         let key = format!("{}{}.json", S3KEY_RESULTS_PREFIX, self.job_id);
@@ -268,13 +275,18 @@ impl PrimitiveJob {
             .get(presigned_url)
             .header("Content-Type", "application/json")
             .send()
-            .await?;
-        if resp.status().is_success() {
+            .await
+            .map_err(|e| QuantumSystemError::from_middleware_error(&e))?;
+        let status = resp.status();
+        if status.is_success() {
             let json_data = resp.json::<T>().await?;
             Ok(json_data)
         } else {
             let json_data = resp.json::<serde_json::Value>().await?;
-            bail!(format!("{:?}", json_data))
+            Err(QuantumSystemError::Api {
+                status,
+                body: format!("{json_data:?}"),
+            })
         }
     }
 
@@ -334,7 +346,9 @@ impl PrimitiveJob {
     pub async fn get_logs(&self) -> Result<String> {
         let in_final_state = self.is_in_final_state().await?;
         if !in_final_state {
-            bail!("Logs are not available until the job is in its final state.".to_string());
+            return Err(QuantumSystemError::JobNotReady(
+                "logs are not available until the job is in its final state".to_string(),
+            ));
         }
 
         let key = format!("{}{}.json", S3KEY_LOGS_PREFIX, self.job_id);
@@ -349,13 +363,17 @@ impl PrimitiveJob {
             .get(presigned_url)
             .header("Content-Type", "application/json")
             .send()
-            .await?;
+            .await
+            .map_err(|e| QuantumSystemError::from_middleware_error(&e))?;
         let status = resp.status();
         let text_data = resp.text().await?;
         if status.is_success() {
             Ok(text_data)
         } else {
-            bail!(text_data)
+            Err(QuantumSystemError::Api {
+                status,
+                body: text_data,
+            })
         }
     }
 }

--- a/dependencies/quantum_system_client/src/api/service_version.rs
+++ b/dependencies/quantum_system_client/src/api/service_version.rs
@@ -11,7 +11,7 @@
 
 use crate::models::version::ServiceVersion;
 use crate::Client;
-use anyhow::Result;
+use crate::Result;
 
 impl Client {
     /// Returns the latest supported API version.
@@ -38,7 +38,9 @@ impl Client {
     ///
     pub async fn get_service_version(&self) -> Result<String> {
         let url = format!("{}/version", self.base_url,);
-        let json_data = self.get::<ServiceVersion>(&url, &self.plain_client).await?;
+        let json_data = self
+            .get::<ServiceVersion>(&url, &self.plain_client, crate::error::ResourceKind::Other)
+            .await?;
         Ok(json_data.version)
     }
 }

--- a/dependencies/quantum_system_client/src/client.rs
+++ b/dependencies/quantum_system_client/src/client.rs
@@ -11,15 +11,16 @@
 
 //! Quantum System API Client
 
-use anyhow::{bail, Result};
+use crate::error::QuantumSystemError;
+use crate::middleware::retry::TransparentRetryMiddleware;
+use crate::Result;
 use std::time::Duration;
 
 #[allow(unused_imports)]
-use log::{error, info, warn};
+use log::warn;
 use reqwest::header;
 use reqwest_middleware::ClientBuilder as ReqwestClientBuilder;
 use reqwest_retry::policies::ExponentialBackoff;
-use reqwest_retry::RetryTransientMiddleware;
 #[cfg(feature = "iqp_retry_policy")]
 use reqwest_retry::{
     default_on_request_failure, default_on_request_success, Jitter, Retryable, RetryableStrategy,
@@ -36,7 +37,6 @@ use std::error::Error;
 use std::env;
 
 use crate::middleware::auth::{AuthMiddleware, TokenManager};
-use crate::models::errors::ExtendedErrorResponse;
 
 #[cfg(feature = "iqp_retry_policy")]
 struct RetryStrategyExcept429;
@@ -44,7 +44,7 @@ struct RetryStrategyExcept429;
 impl RetryableStrategy for RetryStrategyExcept429 {
     fn handle(
         &self,
-        res: &Result<reqwest::Response, reqwest_middleware::Error>,
+        res: &std::result::Result<reqwest::Response, reqwest_middleware::Error>,
     ) -> Option<Retryable> {
         match res {
             Ok(success) if success.status() == 429 || success.status() == 423 => None,
@@ -60,15 +60,23 @@ struct RetryStrategy429;
 impl RetryableStrategy for RetryStrategy429 {
     fn handle(
         &self,
-        res: &Result<reqwest::Response, reqwest_middleware::Error>,
+        res: &std::result::Result<reqwest::Response, reqwest_middleware::Error>,
     ) -> Option<Retryable> {
         match res {
             Ok(success) if success.status() == 429 || success.status() == 423 => {
                 Some(Retryable::Transient)
             }
-            Ok(_success) => None,
-            // but maybe retry a request failure
-            Err(error) => default_on_request_failure(error),
+            // Everything else -- including a network-level failure -- is
+            // not this layer's concern. Returning `None` (rather than
+            // delegating to `default_on_request_failure`, as before) lets
+            // it fall through untouched to the `RetryStrategyExcept429`
+            // layer wrapping this one, which retries it with the normal,
+            // *bounded* policy. Without this, a plain connection/DNS
+            // failure would also be retried here under `retry_policy_429`,
+            // whose retry count is deliberately unlimited (appropriate for
+            // "keep waiting out a rate limit", not for "keep redialing an
+            // address that will never resolve").
+            _ => None,
         }
     }
 }
@@ -127,6 +135,7 @@ impl Client {
         &self,
         url: &str,
         client: &reqwest_middleware::ClientWithMiddleware,
+        resource_kind: crate::error::ResourceKind,
     ) -> Result<T> {
         let resp_ = client.get(url).send().await;
         match resp_ {
@@ -136,39 +145,10 @@ impl Client {
                     let json_text = resp.text().await?;
                     Ok(serde_json::from_str::<T>(&json_text)?)
                 } else {
-                    match resp.json::<ExtendedErrorResponse>().await {
-                        Ok(ExtendedErrorResponse::Json(error)) => {
-                            let serialized = serde_json::to_value(&error).unwrap();
-                            error!("{}", &serialized);
-                            bail!(format!(
-                                "An error occurred while fetching data from API. {}",
-                                &serialized
-                            ));
-                        }
-                        Ok(ExtendedErrorResponse::Text(message)) => {
-                            error!("{}", message);
-                            bail!(format!(
-                                "An error occurred while fetching data from API. {} ({})",
-                                status, message
-                            ));
-                        }
-                        Err(_) => {
-                            error!("{} {}", status, url);
-                            bail!(format!(
-                                "An error occurred while fetching data from API. {} {}",
-                                status, url
-                            ));
-                        }
-                    }
+                    Err(QuantumSystemError::from_response(status, resp, url, resource_kind).await)
                 }
             }
-            Err(e) => {
-                let err_msg = Client::explain_reqwest_middleware_error(&e);
-                bail!(format!(
-                    "An error occurred while fetching data from API. {}",
-                    err_msg
-                ));
-            }
+            Err(e) => Err(QuantumSystemError::from_middleware_error(&e)),
         }
     }
 
@@ -498,11 +478,13 @@ impl ClientBuilder {
         let mut headers = header::HeaderMap::new();
         headers.insert(
             header::ACCEPT,
-            header::HeaderValue::from_str("application/json")?,
+            header::HeaderValue::from_str("application/json")
+                .map_err(|e| QuantumSystemError::other("invalid header value", e))?,
         );
         #[cfg(feature = "api_version")]
         if let Some(api_ver_value) = &self.api_version {
-            let api_ver_value = header::HeaderValue::from_str(api_ver_value.as_str())?;
+            let api_ver_value = header::HeaderValue::from_str(api_ver_value.as_str())
+                .map_err(|e| QuantumSystemError::other("invalid header value", e))?;
             headers.insert("IBM-API-Version", api_ver_value);
         }
         #[cfg(feature = "internal_shared_key_auth")]
@@ -512,13 +494,15 @@ impl ClientBuilder {
         } = self.auth_method.clone()
         {
             let auth_str = format!("apikey {}:{}", client_id, shared_token);
-            let mut auth_value = header::HeaderValue::from_str(auth_str.as_str())?;
+            let mut auth_value = header::HeaderValue::from_str(auth_str.as_str())
+                .map_err(|e| QuantumSystemError::other("invalid header value", e))?;
             auth_value.set_sensitive(true);
             headers.insert(header::AUTHORIZATION, auth_value);
         }
 
         if let AuthMethod::IbmCloudIam { service_crn, .. } = self.auth_method.clone() {
-            let service_crn_value = header::HeaderValue::from_str(&service_crn)?;
+            let service_crn_value = header::HeaderValue::from_str(&service_crn)
+                .map_err(|e| QuantumSystemError::other("invalid header value", e))?;
             headers.insert("Service-CRN", service_crn_value);
         }
 
@@ -529,31 +513,8 @@ impl ClientBuilder {
             ReqwestClientBuilder::new(reqwest_plain_client_builder.build()?);
 
         if let Some(v) = self.retry_policy {
-            #[cfg(feature = "iqp_retry_policy")]
-            {
-                let mut retry_policy_429 = ExponentialBackoff::builder()
-                    .retry_bounds(Duration::from_secs(1), Duration::from_secs(60))
-                    .jitter(Jitter::Bounded)
-                    .base(2)
-                    .build_with_max_retries(1);
-                retry_policy_429.max_n_retries = None;
-                middleware_client_builder = middleware_client_builder
-                    .with(RetryTransientMiddleware::new_with_policy_and_strategy(
-                        v,
-                        RetryStrategyExcept429,
-                    ))
-                    .with(RetryTransientMiddleware::new_with_policy_and_strategy(
-                        retry_policy_429,
-                        RetryStrategy429,
-                    ))
-            }
-            #[cfg(not(feature = "iqp_retry_policy"))]
-            {
-                middleware_client_builder =
-                    middleware_client_builder.with(RetryTransientMiddleware::new_with_policy(v));
-            }
             middleware_plain_client_builder =
-                middleware_plain_client_builder.with(RetryTransientMiddleware::new_with_policy(v));
+                middleware_plain_client_builder.with(TransparentRetryMiddleware::new_with_policy(v));
         };
 
         #[cfg(feature = "ibmcloud_appid_auth")]
@@ -588,6 +549,45 @@ impl ClientBuilder {
             let auth_middleware = AuthMiddleware::new(token_manager.clone());
             middleware_client_builder = middleware_client_builder.with(auth_middleware);
         }
+
+        // Attached *after* (and so, since middleware runs in attachment
+        // order, *inside* -- see `TransparentRetryMiddleware`'s docs)
+        // both `auth_middleware` blocks above. This matters: if retry
+        // instead wrapped auth (as it did previously), a transient failure
+        // on the actual request would cause the *whole*
+        // `AuthMiddleware::handle()` call to be retried, including
+        // redundantly re-running its own internal, already-retried token
+        // acquisition every single time -- turning what should be a
+        // handful of attempts into a multiplicative explosion (outer
+        // retries x inner retries). With retry innermost, it only ever
+        // retries the actual request send, while token acquisition (with
+        // its own independent retry policy, see `TokenManager::new`)
+        // happens exactly once per call.
+        if let Some(v) = self.retry_policy {
+            #[cfg(feature = "iqp_retry_policy")]
+            {
+                let mut retry_policy_429 = ExponentialBackoff::builder()
+                    .retry_bounds(Duration::from_secs(1), Duration::from_secs(60))
+                    .jitter(Jitter::Bounded)
+                    .base(2)
+                    .build_with_max_retries(1);
+                retry_policy_429.max_n_retries = None;
+                middleware_client_builder = middleware_client_builder
+                    .with(TransparentRetryMiddleware::new_with_policy_and_strategy(
+                        v,
+                        RetryStrategyExcept429,
+                    ))
+                    .with(TransparentRetryMiddleware::new_with_policy_and_strategy(
+                        retry_policy_429,
+                        RetryStrategy429,
+                    ))
+            }
+            #[cfg(not(feature = "iqp_retry_policy"))]
+            {
+                middleware_client_builder =
+                    middleware_client_builder.with(TransparentRetryMiddleware::new_with_policy(v));
+            }
+        };
 
         let client = middleware_client_builder.build();
         let plain_client = middleware_plain_client_builder.build();

--- a/dependencies/quantum_system_client/src/client.rs
+++ b/dependencies/quantum_system_client/src/client.rs
@@ -513,8 +513,8 @@ impl ClientBuilder {
             ReqwestClientBuilder::new(reqwest_plain_client_builder.build()?);
 
         if let Some(v) = self.retry_policy {
-            middleware_plain_client_builder =
-                middleware_plain_client_builder.with(TransparentRetryMiddleware::new_with_policy(v));
+            middleware_plain_client_builder = middleware_plain_client_builder
+                .with(TransparentRetryMiddleware::new_with_policy(v));
         };
 
         #[cfg(feature = "ibmcloud_appid_auth")]

--- a/dependencies/quantum_system_client/src/error.rs
+++ b/dependencies/quantum_system_client/src/error.rs
@@ -1,0 +1,237 @@
+//
+// (C) Copyright IBM 2024-2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! Error type for this crate.
+//!
+//! Every public `Client`/`PrimitiveJob` method returns [`Result<T>`], where
+//! the error is [`QuantumSystemError`] rather than a bare `anyhow::Error`, so
+//! callers can match on *why* a call failed (a network-level failure vs. an
+//! API error response vs. a job that isn't in the right state yet) instead
+//! of parsing message text.
+//!
+//! One exception: [`crate::middleware::auth`]'s `Middleware` trait impl
+//! must return `reqwest_middleware::Result<T>`, and that crate's own
+//! `reqwest_middleware::Error::Middleware` variant specifically requires an
+//! `anyhow::Error` -- that's an external constraint we don't control, so
+//! that one file continues to build errors with `anyhow!` rather than
+//! `QuantumSystemError`.
+
+use http::StatusCode;
+use thiserror::Error;
+
+/// What kind of resource a request was about. On its own, a 404 doesn't say
+/// *what* wasn't found -- this lets [`QuantumSystemError::from_response`]
+/// turn that into [`QuantumSystemError::BackendNotFound`] or
+/// [`QuantumSystemError::JobNotFound`] instead of a generic message.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResourceKind {
+    Backend,
+    Job,
+    /// Endpoints where a 404 doesn't correspond to one specific missing
+    /// resource (list endpoints, service-level metadata, ...), or where a
+    /// 404 isn't expected in practice. Falls back to the generic
+    /// [`QuantumSystemError::Api`].
+    Other,
+}
+
+/// Errors returned by this crate.
+#[derive(Error, Debug)]
+pub enum QuantumSystemError {
+    /// The HTTP request could not be completed at all -- no response was
+    /// received from the server (connection failure, TLS error, access
+    /// token refresh failure, retry policy exhausted, ...).
+    #[error("request failed: {0}")]
+    Request(String),
+
+    /// HTTP 401: the request's credentials were missing or rejected.
+    #[error("authentication failed: {0}")]
+    AuthenticationFailed(String),
+
+    /// HTTP 403: the caller is authenticated but not permitted to perform
+    /// this operation (e.g. the backend is reserved and this job is outside
+    /// of the reservation).
+    #[error("access denied: {0}")]
+    AccessDenied(String),
+
+    /// HTTP 404 for a request about a specific backend: the named backend
+    /// does not exist.
+    #[error("backend not found: {0}")]
+    BackendNotFound(String),
+
+    /// HTTP 404 for a request about a specific job: the named job does not
+    /// exist (or has already been deleted).
+    #[error("job not found: {0}")]
+    JobNotFound(String),
+
+    /// HTTP 408: the server timed out reading the request.
+    #[error("request timeout: {0}")]
+    RequestTimeout(String),
+
+    /// HTTP 400, 409, 413, or 422: the job input was rejected -- malformed,
+    /// too large, conflicting with an existing job ID, or otherwise
+    /// well-formed but invalid. `body` is the API's own description of
+    /// what was wrong.
+    #[error("invalid job input: {0}")]
+    InvalidJobInput(String),
+
+    /// HTTP 429: no execution lane is currently available (e.g. the
+    /// per-backend concurrent job limit has been reached).
+    #[error("execution lanes full: {0}")]
+    ExecutionLanesFull(String),
+
+    /// HTTP 5xx: the server reported an internal error.
+    #[error("server error: {0}")]
+    ServerError(String),
+
+    /// A non-success HTTP status that doesn't map to any of the more
+    /// specific variants above.
+    #[error("API error ({status}): {body}")]
+    Api { status: StatusCode, body: String },
+
+    /// The requested operation isn't valid for the job's current state
+    /// (e.g. results or logs requested before the job reached a final
+    /// state, or a timeout while waiting for one).
+    #[error("{0}")]
+    JobNotReady(String),
+
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Catch-all for errors from a lower-level SDK (e.g. `aws-sdk-s3`) that
+    /// don't warrant their own variant. Still carries the original error as
+    /// `source` for anyone inspecting the chain (`std::error::Error::source`).
+    #[error("{message}")]
+    Other {
+        message: String,
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    },
+}
+
+impl QuantumSystemError {
+    /// Wraps an arbitrary error (typically from a lower-level SDK such as
+    /// `aws-sdk-s3`, whose error types are awkward to name individually
+    /// since they're generic over the operation) with a short description
+    /// of what was being attempted.
+    pub(crate) fn other(
+        context: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        let context = context.into();
+        QuantumSystemError::Other {
+            message: format!("{context}: {source}"),
+            source: Some(Box::new(source)),
+        }
+    }
+
+    /// Builds a [`QuantumSystemError`] from a failed `reqwest_middleware`
+    /// request (the request never got a response from the quantum system
+    /// API itself). `reqwest_middleware::Error` has two variants:
+    /// `Reqwest`, a lower-level transport failure (DNS, TLS, connection
+    /// refused, ...), which becomes the generic
+    /// [`QuantumSystemError::Request`]; and `Middleware`, which -- in this
+    /// crate -- is only ever constructed by [`crate::middleware::auth`]
+    /// when it fails to obtain or refresh an access token, so it's always
+    /// classified as [`QuantumSystemError::AuthenticationFailed`].
+    ///
+    /// This distinction relies on the retry middleware
+    /// ([`crate::middleware::retry::TransparentRetryMiddleware`]) *not*
+    /// rewrapping errors on its way out -- unlike
+    /// `reqwest_retry::RetryTransientMiddleware`, which unconditionally
+    /// rewraps whatever error it receives (even after zero retries) into
+    /// an opaque `RetryError`, collapsing this exact distinction. See that
+    /// module's docs for the history of why we don't use it.
+    /// [`crate::Client::explain_reqwest_middleware_error`] is used to
+    /// unwrap the underlying reason out of the middleware chain for the
+    /// message text in every case.
+    pub(crate) fn from_middleware_error(err: &reqwest_middleware::Error) -> Self {
+        let msg = crate::Client::explain_reqwest_middleware_error(err);
+        match err {
+            reqwest_middleware::Error::Middleware(_) => {
+                QuantumSystemError::AuthenticationFailed(msg)
+            }
+            reqwest_middleware::Error::Reqwest(_) => QuantumSystemError::Request(msg),
+        }
+    }
+
+    /// Builds the appropriate `QuantumSystemError` variant from a
+    /// non-success HTTP response, mapping well-known status codes (401,
+    /// 403, 404, 408, 429, 5xx, and 400/409/413/422) onto a specific
+    /// variant and falling back to the generic [`QuantumSystemError::Api`]
+    /// for anything else. `resource_kind` disambiguates a 404 between
+    /// [`QuantumSystemError::BackendNotFound`] and
+    /// [`QuantumSystemError::JobNotFound`] -- the status code alone doesn't
+    /// say which. In every case, `body` holds whatever level of detail
+    /// could be extracted from the response (a structured JSON error, a
+    /// plain text message, or a fallback description if the body was
+    /// neither). Used by every API call site that gets as far as a
+    /// response but finds it isn't a success, so each one doesn't have to
+    /// repeat this status-code mapping itself.
+    pub(crate) async fn from_response(
+        status: StatusCode,
+        resp: reqwest::Response,
+        url: &str,
+        resource_kind: ResourceKind,
+    ) -> Self {
+        let body = Self::extract_body(status, resp, url).await;
+        match status {
+            StatusCode::UNAUTHORIZED => QuantumSystemError::AuthenticationFailed(body),
+            StatusCode::FORBIDDEN => QuantumSystemError::AccessDenied(body),
+            StatusCode::NOT_FOUND => match resource_kind {
+                ResourceKind::Backend => QuantumSystemError::BackendNotFound(body),
+                ResourceKind::Job => QuantumSystemError::JobNotFound(body),
+                ResourceKind::Other => QuantumSystemError::Api { status, body },
+            },
+            StatusCode::REQUEST_TIMEOUT => QuantumSystemError::RequestTimeout(body),
+            StatusCode::BAD_REQUEST
+            | StatusCode::CONFLICT
+            | StatusCode::PAYLOAD_TOO_LARGE
+            | StatusCode::UNPROCESSABLE_ENTITY => QuantumSystemError::InvalidJobInput(body),
+            StatusCode::TOO_MANY_REQUESTS => QuantumSystemError::ExecutionLanesFull(body),
+            s if s.is_server_error() => QuantumSystemError::ServerError(body),
+            _ => QuantumSystemError::Api { status, body },
+        }
+    }
+
+    /// Extracts whatever level of detail is available from a non-success
+    /// response body: a structured JSON error, a plain text message, or --
+    /// if the body couldn't be parsed as either -- a fallback description
+    /// naming the status and request URL.
+    async fn extract_body(status: StatusCode, resp: reqwest::Response, url: &str) -> String {
+        use crate::models::errors::ExtendedErrorResponse;
+        match resp.json::<ExtendedErrorResponse>().await {
+            Ok(ExtendedErrorResponse::Json(error)) => {
+                let body = serde_json::to_value(&error)
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|_| format!("{error:?}"));
+                log::error!("{body}");
+                body
+            }
+            Ok(ExtendedErrorResponse::Text(message)) => {
+                log::error!("{message}");
+                message
+            }
+            Err(_) => {
+                log::error!("{status} {url}");
+                format!("(no error body available; request URL: {url})")
+            }
+        }
+    }
+}
+
+/// Result type used throughout this crate.
+pub type Result<T> = std::result::Result<T, QuantumSystemError>;

--- a/dependencies/quantum_system_client/src/lib.rs
+++ b/dependencies/quantum_system_client/src/lib.rs
@@ -37,6 +37,7 @@
 
 mod api;
 mod client;
+pub mod error;
 #[allow(dead_code)]
 #[allow(unused_imports)]
 mod middleware;
@@ -45,3 +46,4 @@ mod storages;
 pub mod utils;
 
 pub use client::{AuthMethod, Client, ClientBuilder, PrimitiveJob};
+pub use error::{QuantumSystemError, Result};

--- a/dependencies/quantum_system_client/src/middleware.rs
+++ b/dependencies/quantum_system_client/src/middleware.rs
@@ -10,3 +10,4 @@
 // that they have been altered from the originals.
 
 pub mod auth;
+pub(crate) mod retry;

--- a/dependencies/quantum_system_client/src/middleware/auth.rs
+++ b/dependencies/quantum_system_client/src/middleware/auth.rs
@@ -1,5 +1,5 @@
 //
-// (C) Copyright IBM 2024, 2025
+// (C) Copyright IBM 2024-2026
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/dependencies/quantum_system_client/src/middleware/auth.rs
+++ b/dependencies/quantum_system_client/src/middleware/auth.rs
@@ -69,8 +69,7 @@ impl TokenManager {
         let mut reqwest_builder =
             reqwest_middleware::ClientBuilder::new(reqwest_client_builder.build()?);
         if let Some(v) = retry_policy {
-            reqwest_builder =
-                reqwest_builder.with(TransparentRetryMiddleware::new_with_policy(v))
+            reqwest_builder = reqwest_builder.with(TransparentRetryMiddleware::new_with_policy(v))
         } else {
             let default_policy = ExponentialBackoff::builder()
                 .retry_bounds(
@@ -80,9 +79,8 @@ impl TokenManager {
                 .jitter(Jitter::Bounded)
                 .base(DEFAULT_EXPONENTIAL_BASE)
                 .build_with_max_retries(DEFAULT_RETRIES);
-            reqwest_builder = reqwest_builder.with(
-                TransparentRetryMiddleware::new_with_policy(default_policy),
-            )
+            reqwest_builder =
+                reqwest_builder.with(TransparentRetryMiddleware::new_with_policy(default_policy))
         }
         Ok(Self {
             access_token: None,

--- a/dependencies/quantum_system_client/src/middleware/auth.rs
+++ b/dependencies/quantum_system_client/src/middleware/auth.rs
@@ -9,7 +9,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use http::Extensions;
 #[allow(unused_imports)]
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
 use tokio::sync::Mutex;
 
+use crate::middleware::retry::TransparentRetryMiddleware;
 use crate::models::{
     auth::GetAccessTokenResponse, errors::ErrorResponse, errors::IAMErrorResponse,
 };
@@ -49,7 +50,7 @@ impl TokenManager {
         connect_timeout: Option<Duration>,
         read_timeout: Option<Duration>,
         retry_policy: Option<reqwest_retry::policies::ExponentialBackoff>,
-    ) -> Result<Self> {
+    ) -> crate::Result<Self> {
         let mut reqwest_client_builder = reqwest::Client::builder();
         if cfg!(debug_assertions) {
             reqwest_client_builder = reqwest_client_builder.connection_verbose(true);
@@ -69,7 +70,7 @@ impl TokenManager {
             reqwest_middleware::ClientBuilder::new(reqwest_client_builder.build()?);
         if let Some(v) = retry_policy {
             reqwest_builder =
-                reqwest_builder.with(reqwest_retry::RetryTransientMiddleware::new_with_policy(v))
+                reqwest_builder.with(TransparentRetryMiddleware::new_with_policy(v))
         } else {
             let default_policy = ExponentialBackoff::builder()
                 .retry_bounds(
@@ -80,7 +81,7 @@ impl TokenManager {
                 .base(DEFAULT_EXPONENTIAL_BASE)
                 .build_with_max_retries(DEFAULT_RETRIES);
             reqwest_builder = reqwest_builder.with(
-                reqwest_retry::RetryTransientMiddleware::new_with_policy(default_policy),
+                TransparentRetryMiddleware::new_with_policy(default_policy),
             )
         }
         Ok(Self {
@@ -219,10 +220,14 @@ impl Middleware for AuthMiddleware {
             .run(cloned_req.try_clone().unwrap(), extensions)
             .await;
 
-        // retry if token is expired.
-        if response.is_err()
-            || response.as_ref().unwrap().status() == reqwest::StatusCode::UNAUTHORIZED
-        {
+        // Retry with a freshly-renewed token only if the *actual API*
+        // rejected the current one (401) -- not on `response.is_err()`,
+        // which also covers things entirely unrelated to the token (a
+        // connection timeout, DNS failure, ...). Retrying those here would
+        // silently run the *entire* inner retry chain (see
+        // `crate::middleware::retry`) a second time for a problem that
+        // renewing the token can't possibly fix.
+        if matches!(&response, Ok(resp) if resp.status() == reqwest::StatusCode::UNAUTHORIZED) {
             debug!("renew access token");
             token_manager.get_access_token().await?;
             let token = token_manager.get_token().await?;

--- a/dependencies/quantum_system_client/src/middleware/retry.rs
+++ b/dependencies/quantum_system_client/src/middleware/retry.rs
@@ -1,0 +1,118 @@
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! A drop-in replacement for `reqwest_retry::RetryTransientMiddleware` that
+//! doesn't erase the underlying error on the way out.
+//!
+//! `reqwest_retry::RetryTransientMiddleware` -- even when it ends up
+//! retrying zero times -- unconditionally rewraps whatever error escapes
+//! `next.run()` as an opaque `RetryError` before returning it, and that
+//! rewrapping doesn't preserve a `source()` chain. That means any
+//! structured information downstream code (e.g.
+//! [`crate::error::QuantumSystemError::from_middleware_error`]) might want
+//! to recover from the original error -- including which
+//! `reqwest_middleware::Error` variant it actually was -- is unrecoverable
+//! by the time it gets there.
+//!
+//! This middleware reuses the exact same retry *decision* logic (the
+//! `RetryPolicy` and `RetryableStrategy` traits, so retry behavior doesn't
+//! change at all) but, once it's done retrying, hands back whatever
+//! `next.run()` produced completely unchanged instead of wrapping it.
+
+use http::Extensions;
+use reqwest::{Request, Response};
+use reqwest_middleware::{Error, Middleware, Next, Result};
+use reqwest_retry::{DefaultRetryableStrategy, Retryable, RetryableStrategy};
+use retry_policies::{RetryDecision, RetryPolicy};
+use std::time::{Duration, SystemTime};
+
+/// Retries a request according to `retry_policy`/`retryable_strategy`, same
+/// as [`reqwest_retry::RetryTransientMiddleware`], but returns the final
+/// result exactly as received -- see the module docs for why.
+pub(crate) struct TransparentRetryMiddleware<T, R = DefaultRetryableStrategy>
+where
+    T: RetryPolicy + Send + Sync + 'static,
+    R: RetryableStrategy + Send + Sync + 'static,
+{
+    retry_policy: T,
+    retryable_strategy: R,
+}
+
+impl<T> TransparentRetryMiddleware<T, DefaultRetryableStrategy>
+where
+    T: RetryPolicy + Send + Sync + 'static,
+{
+    pub(crate) fn new_with_policy(retry_policy: T) -> Self {
+        Self::new_with_policy_and_strategy(retry_policy, DefaultRetryableStrategy)
+    }
+}
+
+impl<T, R> TransparentRetryMiddleware<T, R>
+where
+    T: RetryPolicy + Send + Sync + 'static,
+    R: RetryableStrategy + Send + Sync + 'static,
+{
+    pub(crate) fn new_with_policy_and_strategy(retry_policy: T, retryable_strategy: R) -> Self {
+        Self {
+            retry_policy,
+            retryable_strategy,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T, R> Middleware for TransparentRetryMiddleware<T, R>
+where
+    T: RetryPolicy + Send + Sync + 'static,
+    R: RetryableStrategy + Send + Sync + 'static,
+{
+    async fn handle(
+        &self,
+        req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        let mut n_past_retries = 0;
+        let start_time = SystemTime::now();
+        loop {
+            // Cloning the request object before-the-fact is not ideal, but
+            // if the body is a static/shared buffer (e.g. `Bytes`) it's
+            // effectively free -- same tradeoff `reqwest_retry` makes.
+            let duplicate_request = req.try_clone().ok_or_else(|| {
+                Error::Middleware(anyhow::anyhow!(
+                    "Request object is not cloneable. Are you passing a streaming body?"
+                ))
+            })?;
+
+            let result = next.clone().run(duplicate_request, extensions).await;
+
+            if let Some(Retryable::Transient) = self.retryable_strategy.handle(&result) {
+                let retry_decision = self.retry_policy.should_retry(start_time, n_past_retries);
+                if let RetryDecision::Retry { execute_after } = retry_decision {
+                    let duration = execute_after
+                        .duration_since(SystemTime::now())
+                        .unwrap_or_else(|_| Duration::default());
+                    tokio::time::sleep(duration).await;
+                    n_past_retries += 1;
+                    continue;
+                }
+            }
+
+            // Unlike `reqwest_retry::RetryTransientMiddleware`, return
+            // exactly what `next.run()` produced -- no `RetryError`
+            // rewrapping, so the original `reqwest_middleware::Error`
+            // variant (and whatever's inside a `Middleware` variant, such
+            // as an IAM token-acquisition failure) survives intact for
+            // whoever classifies it downstream.
+            return result;
+        }
+    }
+}

--- a/dependencies/quantum_system_client/src/models/backend_configuration.rs
+++ b/dependencies/quantum_system_client/src/models/backend_configuration.rs
@@ -102,7 +102,6 @@ pub struct TimingConstraints {
 /// # Example
 ///
 /// ```no_run
-/// use anyhow::Result;
 /// use quantum_system_api::{AuthMethod, ClientBuilder};
 ///
 /// #[tokio::main]

--- a/dependencies/quantum_system_client/src/storages/s3.rs
+++ b/dependencies/quantum_system_client/src/storages/s3.rs
@@ -1,5 +1,5 @@
 //
-// (C) Copyright IBM 2024, 2025
+// (C) Copyright IBM 2024-2026
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/dependencies/quantum_system_client/src/storages/s3.rs
+++ b/dependencies/quantum_system_client/src/storages/s3.rs
@@ -9,12 +9,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use anyhow::{bail, Result};
+use crate::error::QuantumSystemError;
+use crate::Result;
 use aws_sdk_s3::presigning::PresigningConfig;
 use aws_sdk_s3::Client;
 use core::time::Duration;
-
-use aws_sdk_s3::error::ProvideErrorMetadata;
 
 /// Returns S3 presigned URL for GET operation
 ///
@@ -30,7 +29,8 @@ pub async fn get_presigned_url(
     expiration: u64,
 ) -> Result<String> {
     let expires_in = Duration::from_secs(expiration);
-    let presigned_config = PresigningConfig::expires_in(expires_in)?;
+    let presigned_config = PresigningConfig::expires_in(expires_in)
+        .map_err(|e| QuantumSystemError::other("invalid presigning duration", e))?;
     let presigned_url = match client
         .get_object()
         .bucket(bucket_name)
@@ -40,8 +40,10 @@ pub async fn get_presigned_url(
     {
         Ok(val) => val,
         Err(err) => {
-            let err = err.into_service_error();
-            bail!(format!("{}", err.message().unwrap()));
+            return Err(QuantumSystemError::other(
+                "failed to presign GET request",
+                err.into_service_error(),
+            ))
         }
     };
     Ok(presigned_url.uri().to_string())
@@ -61,7 +63,8 @@ pub async fn get_presigned_url_for_put(
     expiration: u64,
 ) -> Result<String> {
     let expires_in = Duration::from_secs(expiration);
-    let presigned_config = PresigningConfig::expires_in(expires_in)?;
+    let presigned_config = PresigningConfig::expires_in(expires_in)
+        .map_err(|e| QuantumSystemError::other("invalid presigning duration", e))?;
     let presigned_url = match client
         .put_object()
         .bucket(bucket_name)
@@ -71,8 +74,10 @@ pub async fn get_presigned_url_for_put(
     {
         Ok(val) => val,
         Err(err) => {
-            let err = err.into_service_error();
-            bail!(format!("{}", err.message().unwrap()));
+            return Err(QuantumSystemError::other(
+                "failed to presign PUT request",
+                err.into_service_error(),
+            ))
         }
     };
     Ok(presigned_url.uri().to_string())

--- a/dependencies/quantum_system_client/src/utils/s3.rs
+++ b/dependencies/quantum_system_client/src/utils/s3.rs
@@ -11,8 +11,8 @@
 
 //! Helpers which provide minimum functionalities for operating S3 objects.
 
-use anyhow::{bail, Result};
-use aws_sdk_s3::error::DisplayErrorContext;
+use crate::error::QuantumSystemError;
+use crate::Result;
 use aws_sdk_s3::presigning::PresigningConfig;
 use core::time::Duration;
 
@@ -85,7 +85,8 @@ impl S3Client {
         key_name: impl Into<String>,
         expires_in: u64,
     ) -> Result<String> {
-        let presigned_config = PresigningConfig::expires_in(Duration::from_secs(expires_in))?;
+        let presigned_config = PresigningConfig::expires_in(Duration::from_secs(expires_in))
+            .map_err(|e| QuantumSystemError::other("invalid presigning duration", e))?;
         let presigned_url = match self
             .s3_client
             .get_object()
@@ -96,10 +97,10 @@ impl S3Client {
         {
             Ok(val) => val,
             Err(err) => {
-                bail!(format!(
-                    "An error occurred while generating the presigned URL: {}",
-                    DisplayErrorContext(&err)
-                ));
+                return Err(QuantumSystemError::other(
+                    "An error occurred while generating the presigned URL",
+                    err.into_service_error(),
+                ))
             }
         };
         Ok(presigned_url.uri().to_string())
@@ -126,7 +127,8 @@ impl S3Client {
         key_name: impl Into<String>,
         expires_in: u64,
     ) -> Result<String> {
-        let presigned_config = PresigningConfig::expires_in(Duration::from_secs(expires_in))?;
+        let presigned_config = PresigningConfig::expires_in(Duration::from_secs(expires_in))
+            .map_err(|e| QuantumSystemError::other("invalid presigning duration", e))?;
         let presigned_url = match self
             .s3_client
             .put_object()
@@ -137,10 +139,10 @@ impl S3Client {
         {
             Ok(val) => val,
             Err(err) => {
-                bail!(format!(
-                    "An error occurred while generating the presigned URL: {}",
-                    DisplayErrorContext(&err)
-                ));
+                return Err(QuantumSystemError::other(
+                    "An error occurred while generating the presigned URL",
+                    err.into_service_error(),
+                ))
             }
         };
         Ok(presigned_url.uri().to_string())
@@ -180,10 +182,10 @@ impl S3Client {
         {
             Ok(val) => val,
             Err(err) => {
-                bail!(format!(
-                    "An error occurred while adding an object to S3 bucket: {}",
-                    DisplayErrorContext(&err)
-                ));
+                return Err(QuantumSystemError::other(
+                    "An error occurred while adding an object to S3 bucket",
+                    err.into_service_error(),
+                ))
             }
         };
         Ok(())
@@ -220,15 +222,20 @@ impl S3Client {
         {
             Ok(val) => val,
             Err(err) => {
-                bail!(format!(
-                    "An error occurred while retrieving an object from S3 bucket: {}",
-                    DisplayErrorContext(&err)
-                ));
+                return Err(QuantumSystemError::other(
+                    "An error occurred while retrieving an object from S3 bucket",
+                    err.into_service_error(),
+                ))
             }
         };
 
         let mut data = Vec::<u8>::new();
-        while let Some(bytes) = object.body.try_next().await? {
+        while let Some(bytes) = object
+            .body
+            .try_next()
+            .await
+            .map_err(|e| QuantumSystemError::other("failed to read object body from S3", e))?
+        {
             data.append(&mut bytes.to_vec());
         }
         Ok(data)
@@ -265,10 +272,10 @@ impl S3Client {
         {
             Ok(val) => val,
             Err(err) => {
-                bail!(format!(
-                    "An error occurred while deleting an object from S3 bucket: {}",
-                    DisplayErrorContext(&err)
-                ));
+                return Err(QuantumSystemError::other(
+                    "An error occurred while deleting an object from S3 bucket",
+                    err.into_service_error(),
+                ))
             }
         };
         Ok(())
@@ -319,10 +326,10 @@ impl S3Client {
                     }
                 }
                 Err(err) => {
-                    bail!(format!(
-                        "An error occurred while listing objects in S3 bucket: {}",
-                        DisplayErrorContext(&err)
-                    ));
+                    return Err(QuantumSystemError::other(
+                        "An error occurred while listing objects in S3 bucket",
+                        err.into_service_error(),
+                    ))
                 }
             }
         }

--- a/examples/qrmi/c/ibm_quantum_system/src/quantum_system.c
+++ b/examples/qrmi/c/ibm_quantum_system/src/quantum_system.c
@@ -34,8 +34,9 @@ int main(int argc, char *argv[]) {
   QrmiQuantumResource *qrmi =
       qrmi_resource_new(argv[1], QRMI_RESOURCE_TYPE_IBM_QUANTUM_SYSTEM);
   if (!qrmi) {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "Failed to create QRMI for %s. %s (%d)\n", argv[1], last_error, qrmi_get_last_error_kind());
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to create QRMI for %s. %s (%d)\n", argv[1],
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     return EXIT_FAILURE;
   }
@@ -47,8 +48,10 @@ int main(int argc, char *argv[]) {
     QrmiResourceType resource_type;
     rc = qrmi_resource_type(qrmi, &resource_type);
     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-      const char *resource_type_str = qrmi_config_resource_type_to_str(resource_type);
-      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id, resource_type_str);
+      const char *resource_type_str =
+          qrmi_config_resource_type_to_str(resource_type);
+      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id,
+              resource_type_str);
     }
     qrmi_string_free(resource_id);
   }
@@ -78,8 +81,9 @@ int main(int argc, char *argv[]) {
       goto error;
     }
   } else {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s (%d)\n", last_error, qrmi_get_last_error_kind());
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s (%d)\n",
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     goto error;
   }
@@ -116,8 +120,9 @@ int main(int argc, char *argv[]) {
   char *job_id = NULL;
   rc = qrmi_resource_task_start(qrmi, &payload, &job_id);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "failed to start a task. %s(%d)\n", last_error, qrmi_get_last_error_kind());
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "failed to start a task. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     free((void *)input);
     goto error;
@@ -152,7 +157,10 @@ int main(int argc, char *argv[]) {
     fprintf(stdout, "%s\n", logs);
     qrmi_string_free(logs);
   } else {
-    fprintf(stderr, "Failed to retrieve job logs.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to retrieve job logs. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
   }
 
   qrmi_resource_task_stop(qrmi, job_id);

--- a/examples/qrmi/c/ibm_quantum_system/src/quantum_system.c
+++ b/examples/qrmi/c/ibm_quantum_system/src/quantum_system.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[]) {
       qrmi_resource_new(argv[1], QRMI_RESOURCE_TYPE_IBM_QUANTUM_SYSTEM);
   if (!qrmi) {
     const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "Failed to create QRMI for %s. %s\n", argv[1], last_error);
+    fprintf(stderr, "Failed to create QRMI for %s. %s (%d)\n", argv[1], last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     return EXIT_FAILURE;
   }
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
     }
   } else {
     const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s\n", last_error);
+    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s (%d)\n", last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     goto error;
   }
@@ -116,7 +116,9 @@ int main(int argc, char *argv[]) {
   char *job_id = NULL;
   rc = qrmi_resource_task_start(qrmi, &payload, &job_id);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    fprintf(stderr, "failed to start a task.\n");
+    const char* last_error = qrmi_get_last_error();
+    fprintf(stderr, "failed to start a task. %s(%d)\n", last_error, qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
     free((void *)input);
     goto error;
   }

--- a/examples/qrmi/rust/Cargo.lock
+++ b/examples/qrmi/rust/Cargo.lock
@@ -536,6 +536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "qrmi"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "alice-bob-felis",
  "anyhow",
@@ -2135,6 +2144,7 @@ dependencies = [
  "reqwest-retry",
  "serde",
  "serde_json",
+ "thiserror 2.0.20",
  "tokio",
  "uuid",
 ]
@@ -2229,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "quantum-system-api"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2865,6 +2875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",

--- a/src/cext.rs
+++ b/src/cext.rs
@@ -44,8 +44,6 @@ pub enum ReturnCode {
     ParseError = 103,
     /// Dynamic discovery was requested for an unsupported resource type.
     UnsupportedResourceTypeError = 104,
-    /// An unrecognized program/primitive ID was supplied.
-    UnknownProgramIdError = 105,
     /// The payload variant is not supported by this backend.
     UnsupportedPayloadError = 106,
     /// The task is not in a state that allows the requested operation.
@@ -71,7 +69,6 @@ impl From<QrmiErrorKind> for ReturnCode {
             QrmiErrorKind::EnvVarNotSet => ReturnCode::EnvVarNotSetError,
             QrmiErrorKind::ParseError => ReturnCode::ParseError,
             QrmiErrorKind::UnsupportedResourceType => ReturnCode::UnsupportedResourceTypeError,
-            QrmiErrorKind::UnknownProgramId => ReturnCode::UnknownProgramIdError,
             QrmiErrorKind::UnsupportedPayload => ReturnCode::UnsupportedPayloadError,
             QrmiErrorKind::TaskNotReady => ReturnCode::TaskNotReadyError,
             QrmiErrorKind::MissingConfigKey => ReturnCode::MissingConfigKeyError,

--- a/src/cext.rs
+++ b/src/cext.rs
@@ -716,7 +716,7 @@ pub unsafe extern "C" fn qrmi_config_resource_names_get(
 pub unsafe extern "C" fn qrmi_get_last_error() -> *const c_char {
     crate::common::initialize();
     LAST_ERROR.with(|cell| match &*cell.borrow() {
-        Some(cstr) => cstr.as_ptr(),
+        Some(cstr) => cstr.clone().into_raw(),
         None => std::ptr::null(),
     })
 }

--- a/src/cext.rs
+++ b/src/cext.rs
@@ -56,6 +56,13 @@ pub enum ReturnCode {
     InvalidFilterError = 109,
     /// A value was invalid for a reason not covered by a more specific code.
     InvalidValueError = 110,
+    /// The named resource (e.g. a backend) does not exist.
+    ResourceNotFoundError = 111,
+    /// The named task (e.g. a job) does not exist, or has already been
+    /// removed.
+    TaskNotFoundError = 112,
+    /// The request's credentials were missing or rejected.
+    AuthenticationFailedError = 113,
 }
 
 impl From<QrmiErrorKind> for ReturnCode {
@@ -68,6 +75,9 @@ impl From<QrmiErrorKind> for ReturnCode {
             QrmiErrorKind::UnsupportedPayload => ReturnCode::UnsupportedPayloadError,
             QrmiErrorKind::TaskNotReady => ReturnCode::TaskNotReadyError,
             QrmiErrorKind::MissingConfigKey => ReturnCode::MissingConfigKeyError,
+            QrmiErrorKind::ResourceNotFound => ReturnCode::ResourceNotFoundError,
+            QrmiErrorKind::TaskNotFound => ReturnCode::TaskNotFoundError,
+            QrmiErrorKind::AuthenticationFailed => ReturnCode::AuthenticationFailedError,
             QrmiErrorKind::InvalidFilter => ReturnCode::InvalidFilterError,
             QrmiErrorKind::InvalidValue => ReturnCode::InvalidValueError,
             QrmiErrorKind::Other => ReturnCode::Error,
@@ -247,7 +257,6 @@ fn _fail(err: QrmiError) -> ReturnCode {
 /// value directly.
 fn _record_error(err: QrmiError) {
     let kind = err.kind();
-    eprintln!("[DEBUG] _record_error kind={:?}", kind); // 一時的に追加
     LAST_ERROR_KIND.with(|cell| *cell.borrow_mut() = kind);
     _set_last_error(err.to_string());
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -168,8 +168,6 @@ pub enum QrmiErrorKind {
     ParseError,
     /// Dynamic discovery was requested for an unsupported resource type.
     UnsupportedResourceType,
-    /// An unrecognized program/primitive ID was supplied.
-    UnknownProgramId,
     /// The payload variant is not supported by this backend.
     UnsupportedPayload,
     /// The task is not in a state that allows the requested operation.

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,20 @@ pub enum QrmiError {
     #[error("missing '{0}' in environment map")]
     MissingConfigKey(String),
 
+    /// The named resource (e.g. a backend) does not exist.
+    #[error("resource not found: {0}")]
+    ResourceNotFound(String),
+
+    /// The named task (e.g. a job) does not exist, or has already been
+    /// removed.
+    #[error("task not found: {0}")]
+    TaskNotFound(String),
+
+    /// The request's credentials were missing or rejected by the vendor's
+    /// API.
+    #[error("authentication failed: {0}")]
+    AuthenticationFailed(String),
+
     /// A `filters` string passed to [`crate::ResourceProvider::resources`] was
     /// malformed or contained an invalid value.
     #[error("invalid filter: {0}")]
@@ -124,6 +138,9 @@ impl QrmiError {
             QrmiError::UnsupportedPayload(_) => QrmiErrorKind::UnsupportedPayload,
             QrmiError::TaskNotReady { .. } => QrmiErrorKind::TaskNotReady,
             QrmiError::MissingConfigKey(_) => QrmiErrorKind::MissingConfigKey,
+            QrmiError::ResourceNotFound(_) => QrmiErrorKind::ResourceNotFound,
+            QrmiError::TaskNotFound(_) => QrmiErrorKind::TaskNotFound,
+            QrmiError::AuthenticationFailed(_) => QrmiErrorKind::AuthenticationFailed,
             QrmiError::InvalidFilter(_) => QrmiErrorKind::InvalidFilter,
             QrmiError::InvalidJson(_) => QrmiErrorKind::InvalidValue,
             QrmiError::InvalidUtf8(_) => QrmiErrorKind::InvalidValue,
@@ -159,6 +176,13 @@ pub enum QrmiErrorKind {
     TaskNotReady,
     /// A required key was missing from a provider's environment variable map.
     MissingConfigKey,
+    /// The named resource (e.g. a backend) does not exist.
+    ResourceNotFound,
+    /// The named task (e.g. a job) does not exist, or has already been
+    /// removed.
+    TaskNotFound,
+    /// The request's credentials were missing or rejected.
+    AuthenticationFailed,
     /// A `filters` string was malformed or contained an invalid value.
     InvalidFilter,
     /// A value was invalid for a reason not covered by a more specific kind.

--- a/src/ibm/error.rs
+++ b/src/ibm/error.rs
@@ -43,3 +43,28 @@ impl IbmError {
         }
     }
 }
+
+/// Maps errors from the `quantum_system_api` crate (used by
+/// [`crate::ibm::IBMQuantumSystem`] and [`crate::ibm::IBMQuantumSystemProvider`])
+/// onto [`crate::QrmiError`]. A few conditions that crate can distinguish
+/// map onto specific `QrmiError` variants (a missing backend or job, a
+/// rejected credential); everything else falls back to
+/// [`crate::QrmiError::Other`], still carrying the original error as
+/// `source` so the message and cause chain aren't lost.
+///
+/// This is a plain `impl From`, not a `#[from]` variant on `IbmError` or
+/// `QrmiError` -- `quantum_system_api::QuantumSystemError` doesn't represent
+/// an IBM-specific *condition* the way `IbmError`'s variants do, it's just
+/// the error type of a dependency we're translating, so it doesn't belong
+/// as a variant of either enum.
+impl From<quantum_system_api::QuantumSystemError> for crate::QrmiError {
+    fn from(err: quantum_system_api::QuantumSystemError) -> Self {
+        use quantum_system_api::QuantumSystemError as QsError;
+        match err {
+            QsError::BackendNotFound(msg) => crate::QrmiError::ResourceNotFound(msg),
+            QsError::JobNotFound(msg) => crate::QrmiError::TaskNotFound(msg),
+            QsError::AuthenticationFailed(msg) => crate::QrmiError::AuthenticationFailed(msg),
+            other => crate::QrmiError::Other(anyhow::Error::new(other)),
+        }
+    }
+}

--- a/src/ibm/error.rs
+++ b/src/ibm/error.rs
@@ -38,7 +38,7 @@ pub enum IbmError {
 impl IbmError {
     pub(crate) fn kind(&self) -> QrmiErrorKind {
         match self {
-            IbmError::UnknownProgramId(_) => QrmiErrorKind::UnknownProgramId,
+            IbmError::UnknownProgramId(_) => QrmiErrorKind::InvalidValue,
             IbmError::InvalidSessionMode(_) => QrmiErrorKind::InvalidValue,
         }
     }

--- a/src/ibm/quantum_system.rs
+++ b/src/ibm/quantum_system.rs
@@ -14,7 +14,6 @@ use crate::error::{required_env, QrmiError};
 use crate::ibm::error::IbmError;
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use crate::{QuantumResource, Result};
-use anyhow::Context;
 use log::info;
 use quantum_system_api::utils::s3::S3Client;
 use quantum_system_api::{
@@ -154,8 +153,7 @@ impl QuantumResource for IBMQuantumSystem {
         let backend = self
             .api_client
             .get_backend::<Backend>(&self.backend_name)
-            .await
-            .context("failed to get backend details")?;
+            .await?;
         Ok(matches!(backend.status, BackendStatus::Online))
     }
 
@@ -198,8 +196,7 @@ impl QuantumResource for IBMQuantumSystem {
                 &job_input,
                 None,
             )
-            .await
-            .context("failed to start task")?;
+            .await?;
         Ok(job.job_id)
     }
 

--- a/src/ibm/quantum_system_provider/mod.rs
+++ b/src/ibm/quantum_system_provider/mod.rs
@@ -19,7 +19,6 @@ use crate::ibm::IBMQuantumSystem;
 use crate::QuantumResource;
 use crate::ResourceProvider;
 use crate::{QrmiError, Result};
-use anyhow::Context;
 use async_trait::async_trait;
 use futures::future::join_all;
 use log::warn;
@@ -84,8 +83,7 @@ impl IBMQuantumSystemProvider {
                 service_crn,
                 iam_endpoint_url,
             })
-            .build()
-            .context("failed to build quantum system client")?;
+            .build()?;
 
         Ok(Self {
             client,
@@ -126,11 +124,7 @@ impl ResourceProvider for IBMQuantumSystemProvider {
     ) -> Result<Vec<Box<dyn QuantumResource + Send + Sync>>> {
         let filter = BackendFilter::parse(filters.as_deref().unwrap_or(""))?;
 
-        let backends = self
-            .client
-            .list_backends::<Backends>()
-            .await
-            .context("failed to list backends")?;
+        let backends = self.client.list_backends::<Backends>().await?;
 
         let candidates: Vec<String> = backends
             .backends

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -101,9 +101,7 @@ fn to_py_err(err: QrmiError) -> PyErr {
         QrmiErrorKind::EnvVarNotSet => EnvVarNotSetError::new_err(msg),
         QrmiErrorKind::ParseError | QrmiErrorKind::MissingConfigKey => ConfigError::new_err(msg),
         QrmiErrorKind::UnsupportedResourceType => UnsupportedResourceTypeError::new_err(msg),
-        QrmiErrorKind::UnknownProgramId | QrmiErrorKind::UnsupportedPayload => {
-            UnsupportedPayloadError::new_err(msg)
-        }
+        QrmiErrorKind::UnsupportedPayload => UnsupportedPayloadError::new_err(msg),
         QrmiErrorKind::TaskNotReady => TaskNotReadyError::new_err(msg),
         QrmiErrorKind::InvalidFilter | QrmiErrorKind::InvalidValue => {
             InvalidFilterError::new_err(msg)

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -73,6 +73,24 @@ create_exception!(
     QrmiError_,
     "A `filters` string was malformed or contained an invalid value."
 );
+create_exception!(
+    qrmi._core,
+    ResourceNotFoundError,
+    QrmiError_,
+    "The named resource (e.g. a backend) does not exist."
+);
+create_exception!(
+    qrmi._core,
+    TaskNotFoundError,
+    QrmiError_,
+    "The named task (e.g. a job) does not exist, or has already been removed."
+);
+create_exception!(
+    qrmi._core,
+    AuthenticationFailedError,
+    QrmiError_,
+    "The request's credentials were missing or rejected by the vendor's API."
+);
 
 /// Converts a [`QrmiError`] into the [`PyErr`] subclass matching its kind,
 /// so Python code can `except qrmi.TaskNotReadyError` instead of parsing
@@ -90,6 +108,9 @@ fn to_py_err(err: QrmiError) -> PyErr {
         QrmiErrorKind::InvalidFilter | QrmiErrorKind::InvalidValue => {
             InvalidFilterError::new_err(msg)
         }
+        QrmiErrorKind::ResourceNotFound => ResourceNotFoundError::new_err(msg),
+        QrmiErrorKind::TaskNotFound => TaskNotFoundError::new_err(msg),
+        QrmiErrorKind::AuthenticationFailed => AuthenticationFailedError::new_err(msg),
         QrmiErrorKind::Other => QrmiError_::new_err(msg),
     }
 }
@@ -748,6 +769,15 @@ fn qrmi(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add(
         "InvalidFilterError",
         m.py().get_type::<InvalidFilterError>(),
+    )?;
+    m.add(
+        "ResourceNotFoundError",
+        m.py().get_type::<ResourceNotFoundError>(),
+    )?;
+    m.add("TaskNotFoundError", m.py().get_type::<TaskNotFoundError>())?;
+    m.add(
+        "AuthenticationFailedError",
+        m.py().get_type::<AuthenticationFailedError>(),
     )?;
 
     Ok(())


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->

@yoonho Could you please review and approve ? This PR updates the IBM Quantum System API and QRMI to support the recently introduced typed error enhancements #200 . This work is part of our response to feedback from openQSE. Although many files are affected, the changes are straightforward and mainly consist of replacing generic anyhow::Result usage with appropriate QuantumSystemError mappings.

@awennersteen Added `ResourceNotFound`, `TaskNotFound` and `AuthenticationFailed` to QRMI errors. fyi.

### Summary

Replaces `anyhow::Result`/`anyhow::Error` with a typed `QuantumSystemError` (built with `thiserror`) across every public `Client`/`PrimitiveJob` method in this crate, and fixes several retry-related bugs uncovered while wiring up
error classification end-to-end.

### Motivation

Every fallible operation previously returned `anyhow::Result<T>`. This made it easy to attach context via `.context(...)`, but callers (in this crate's consumer, `qrmi`) had no way to distinguish *why* a call failed short of
string-matching the message — e.g. "the backend doesn't exist" and "the request timed out" were indistinguishable at the type level. This PR introduces a proper error type so callers can match on the actual failure mode instead.

### What changed

#### `QuantumSystemError` (`src/error.rs`)
- New `thiserror`-based enum mapping well-known HTTP status codes onto specific variants: `BackendNotFound`/`JobNotFound` (404, disambiguated via a `ResourceKind` parameter passed at the call site — the status code alone doesn't say which), `AuthenticationFailed` (401), `AccessDenied` (403), `RequestTimeout` (408), `InvalidJobInput` (400/409/413/422), `ExecutionLanesFull` (429), `ServerError` (5xx), and a generic `Api {
  status, body }` fallback for anything else. 
- `Request(String)` covers requests that never got a response at all (connection failure, DNS, TLS, ...).
- `Reqwest`/`Json`/`Io` wrap `reqwest::Error`/`serde_json::Error`/ `std::io::Error` directly via `#[from]`.
- `Other { message, source }` is the catch-all for lower-level SDK errors (e.g. `aws-sdk-s3`) that don't warrant their own variant, still carrying the original error as `source` for anyone inspecting the chain.
- `from_response()` and `from_middleware_error()` centralize the response/error → variant mapping so each of the ~20 call sites doesn't repeat it.

#### Every API call site (`src/api/*.rs`, `src/client.rs`)
- Every `bail!`/`anyhow!` was replaced with a specific `QuantumSystemError` variant; every bare `?` on an external error type now goes through the new `#[from]` conversions or an explicit `.map_err(...)`.
- `middleware/auth.rs`'s `Middleware` trait impl still builds errors with `anyhow!` for the reqwest_middleware::Error::Middleware` variant, since that's dictated by an external crate's type and isn't something we control.

#### Propagation into `qrmi::QrmiError` (`src/error.rs`, `src/ibm/error.rs`)
- `QrmiError` gained three new variants: `ResourceNotFound`, `TaskNotFound`, and `AuthenticationFailed` (same name), plus matching `QrmiErrorKind` entries.
- A new `impl From<quantum_system_api::QuantumSystemError> for QrmiError` in `ibm/error.rs` maps `BackendNotFound → ResourceNotFound`, `JobNotFound → TaskNotFound`, `AuthenticationFailed → AuthenticationFailed` (same name), and everything else into `QrmiError::Other` (still carrying
  the original error as `source`).
- `ibm/quantum_system.rs` and `ibm/quantum_system_provider/mod.rs`'s `.context("...")?` calls into `quantum_system_api` were replaced with plain `?`, since `.context()` would otherwise wrap the error in
  `anyhow::Error` *before* the new `From` conversion gets a chance to run, collapsing everything back into `QrmiError::Other` regardless of the actual cause.

#### C and Python bindings (`src/cext.rs`, `src/pyext.rs`)
- `ReturnCode` gained `ResourceNotFoundError`, `TaskNotFoundError`, and `AuthenticationFailedError` (appended after the existing codes; no renumbering).
- `pyext.rs` gained matching `qrmi.ResourceNotFoundError`, `qrmi.TaskNotFoundError`, and qrmi.AuthenticationFailedError` exception classes, registered in both `to_py_err()`'s mapping and the module's
  `m.add(...)` calls.

#### Retry-related bugs found along the way
Wiring up accurate error classification surfaced three separate, pre-existing retry bugs:

1. **`reqwest_retry::RetryTransientMiddleware` erases error type information.** Even after zero retries, it unconditionally rewraps whatever error it receives into an opaque `RetryError`, discarding the `source()` chain. This made it impossible to reliably tell "IAM rejected the credentials" apart from "a plain DNS failure occurred" once wrapped. Replaced with `middleware/retry.rs`'s `TransparentRetryMiddleware`: same retry *decision* logic (reuses the same `RetryPolicy`/`RetryableStrategy` traits, so behavior is unchanged), but returns the final result unmodified instead of rewrapping it.

2. **Retry multiplication from middleware ordering.** The retry middleware was attached *before* (i.e. outside) `AuthMiddleware`. A transient failure on the actual request caused the *whole* `AuthMiddleware::handle()`
   call to be retried — including redundantly re-running its own internal, already-retried token acquisition every time — turning what should be a handful of attempts into a multiplicative explosion (outer retries × inner retries). Fixed by attaching `AuthMiddleware` first (outermost) and the retry middleware second (innermost, wrapping only the actual request send).
3. **`AuthMiddleware` retried-with-a-fresh-token on *any* error, not just 401.** `response.is_err() || status == 401` triggered a full manual retry (including re-running the entire inner retry chain) for connection timeouts and DNS failures that have nothing to do with token freshness. Narrowed to only retry when the actual API responded with 401.
4. **The `iqp_retry_policy` feature's 429-specific retry strategy also caught generic network failures.** `RetryStrategy429`'s `Err` arm delegated to `default_on_request_failure`, so a connection failure would
   also be retried under `retry_policy_429`'s *unlimited* retry count (appropriate for waiting out a rate limit, not for redialing an address that will never resolve). Narrowed to only handle 429/423; everything else now falls through to the normal, bounded retry layer.

### Backward compatibility

This is a breaking change for `quantum_system_client`'s public API: every method's `Result<T>` error type changes from `anyhow::Error` to `QuantumSystemError`. `QuantumSystemError` implements `std::error::Error`,
so it still converts to `anyhow::Error` automatically via `?` for any consumer that itself uses `anyhow::Result`.

The consuming `qrmi` crate has been updated in a companion change: its own `QrmiError` gained `ResourceNotFound`/`TaskNotFound`/`AuthenticationFailed` variants, and `ibm/quantum_system.rs`'s `.context(...)` calls into this crate were replaced with plain `?` (relying on a new `From<QuantumSystemError> for QrmiError` conversion) so the richer classification isn't lost at that boundary.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
