### PR TITLE
[IQM] Classify IQM Server API errors, consolidate QrmiError's "invalid input" variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,6 +2581,7 @@ dependencies = [
  "ffi_helpers",
  "futures",
  "glob",
+ "http 1.4.0",
  "iqm-server-api",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ munge = ["pasqal-local-api/munge"]
 
 [dependencies]
 reqwest-retry = "0.7.0"
+http = "1.1.0"
 tokio = { version = "1.40.0", features = ["full"] }
 env_logger = "0.11.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
+++ b/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
@@ -39,10 +39,7 @@ pub struct IqmServerQcHealthStatus {
 
 impl IqmServerQcHealthStatus {
     /// The current computer health status
-    pub fn new(
-        operational: String,
-        health: models::QcHealthDetail,
-    ) -> IqmServerQcHealthStatus {
+    pub fn new(operational: String, health: models::QcHealthDetail) -> IqmServerQcHealthStatus {
         IqmServerQcHealthStatus {
             operational,
             health: Box::new(health),
@@ -64,10 +61,7 @@ pub struct QcHealthDetail {
 }
 
 impl QcHealthDetail {
-    pub fn new(
-        healthy: bool,
-        updated_at: chrono::DateTime<chrono::FixedOffset>,
-    ) -> QcHealthDetail {
+    pub fn new(healthy: bool, updated_at: chrono::DateTime<chrono::FixedOffset>) -> QcHealthDetail {
         QcHealthDetail {
             healthy,
             updated_at,

--- a/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
+++ b/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
@@ -15,9 +15,46 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
-/// IqmServerQcHealthStatus : The current computer health status
+/// IqmServerQcHealthStatus : The current computer health status.
+///
+/// NOTE: hand-patched, not regenerated from the OpenAPI spec. The live IQM
+/// Server API wraps the health details one level deeper than what this
+/// crate was originally generated against --
+/// `{"operational": "online", "health": {"healthy": true, "updated_at":
+/// "..."}}` -- instead of the flat `{"healthy": ..., "updated_at": ...}`
+/// this struct used to be. `get_qc_health_v1` (in
+/// `src/apis/quantum_computers_api.rs`) deserializes the whole response
+/// body directly into this type, unchanged, so fixing the shape here was
+/// enough without touching that function. Revert this patch once the crate
+/// is regenerated from an OpenAPI spec that reflects the server's current
+/// response shape.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IqmServerQcHealthStatus {
+    /// Whether the quantum computer is currently accepting jobs.
+    #[serde(rename = "operational")]
+    pub operational: String,
+    #[serde(rename = "health")]
+    pub health: Box<models::QcHealthDetail>,
+}
+
+impl IqmServerQcHealthStatus {
+    /// The current computer health status
+    pub fn new(
+        operational: String,
+        health: models::QcHealthDetail,
+    ) -> IqmServerQcHealthStatus {
+        IqmServerQcHealthStatus {
+            operational,
+            health: Box::new(health),
+        }
+    }
+}
+
+/// The nested `health` object inside [`IqmServerQcHealthStatus`]. This is
+/// what the *old*, flat `IqmServerQcHealthStatus` used to look like before
+/// the hand-patch described on that struct's docs.
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct QcHealthDetail {
     /// Boolean indicating whether the Quantum computer is healthy or not
     #[serde(rename = "healthy")]
     pub healthy: bool,
@@ -26,13 +63,12 @@ pub struct IqmServerQcHealthStatus {
     pub updated_at: chrono::DateTime<chrono::FixedOffset>,
 }
 
-impl IqmServerQcHealthStatus {
-    /// The current computer health status
+impl QcHealthDetail {
     pub fn new(
         healthy: bool,
         updated_at: chrono::DateTime<chrono::FixedOffset>,
-    ) -> IqmServerQcHealthStatus {
-        IqmServerQcHealthStatus {
+    ) -> QcHealthDetail {
+        QcHealthDetail {
             healthy,
             updated_at,
         }

--- a/dependencies/iqm_client/src/models/mod.rs
+++ b/dependencies/iqm_client/src/models/mod.rs
@@ -81,7 +81,7 @@ pub use self::iqm_server_job_sweep_progress::IqmServerJobSweepProgress;
 pub mod iqm_server_job_timeline_event;
 pub use self::iqm_server_job_timeline_event::IqmServerJobTimelineEvent;
 pub mod iqm_server_qc_health_status;
-pub use self::iqm_server_qc_health_status::IqmServerQcHealthStatus;
+pub use self::iqm_server_qc_health_status::{IqmServerQcHealthStatus, QcHealthDetail};
 pub mod iqm_server_qc_limits;
 pub use self::iqm_server_qc_limits::IqmServerQcLimits;
 pub mod iqm_server_qc_queue_overview;

--- a/examples/qrmi/c/iqm_server/src/iqm_server.c
+++ b/examples/qrmi/c/iqm_server/src/iqm_server.c
@@ -23,9 +23,8 @@ extern const char *read_file(const char *);
 int main(int argc, char *argv[]) {
 
   if (argc != 4) {
-    fprintf(
-        stderr,
-        "iqm_server <qc_alias> <IQM JSON> <job_type('circuit','run' or 'sweep')>\n");
+    fprintf(stderr, "iqm_server <qc_alias> <IQM JSON> "
+                    "<job_type('circuit','run' or 'sweep')>\n");
     return EXIT_SUCCESS;
   }
 
@@ -34,8 +33,9 @@ int main(int argc, char *argv[]) {
   QrmiQuantumResource *qrmi =
       qrmi_resource_new(argv[1], QRMI_RESOURCE_TYPE_IQM_SERVER);
   if (!qrmi) {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "Failed to create QRMI for %s. %s\n", argv[1], last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to create QRMI for %s. %s (%d)\n", argv[1],
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     return EXIT_FAILURE;
   }
@@ -47,8 +47,10 @@ int main(int argc, char *argv[]) {
     QrmiResourceType resource_type;
     rc = qrmi_resource_type(qrmi, &resource_type);
     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-      const char *resource_type_str = qrmi_config_resource_type_to_str(resource_type);
-      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id, resource_type_str);
+      const char *resource_type_str =
+          qrmi_config_resource_type_to_str(resource_type);
+      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id,
+              resource_type_str);
     }
     qrmi_string_free(resource_id);
   }
@@ -78,8 +80,9 @@ int main(int argc, char *argv[]) {
       goto error;
     }
   } else {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s\n", last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s (%d)\n",
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     goto error;
   }
@@ -87,7 +90,10 @@ int main(int argc, char *argv[]) {
   char *acquisition_token = NULL;
   rc = qrmi_resource_acquire(qrmi, &acquisition_token);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    fprintf(stdout, "qrmi_resource_acquire() failed.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stdout, "qrmi_resource_acquire() failed. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
     goto error;
   }
   fprintf(stdout, "acquisition_token = %s\n", acquisition_token);
@@ -102,7 +108,10 @@ int main(int argc, char *argv[]) {
     fprintf(stdout, "target = %s\n", target);
     qrmi_string_free((char *)target);
   } else {
-    fprintf(stderr, "qrmi_resource_target() failed.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "qrmi_resource_target() failed. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
     goto error;
   }
 
@@ -119,7 +128,10 @@ int main(int argc, char *argv[]) {
   char *job_id = NULL;
   rc = qrmi_resource_task_start(qrmi, &payload, &job_id);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    fprintf(stderr, "failed to start a task.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "failed to start a task. . %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
     free((void *)input);
     goto error;
   }
@@ -153,10 +165,19 @@ int main(int argc, char *argv[]) {
     fprintf(stdout, "%s\n", logs);
     qrmi_string_free(logs);
   } else {
-    fprintf(stderr, "Failed to retrieve job logs.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to retrieve job logs. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
   }
 
-  qrmi_resource_task_stop(qrmi, job_id);
+  rc = qrmi_resource_task_stop(qrmi, job_id);
+  if (rc != QRMI_RETURN_CODE_SUCCESS) {
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to stop task. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
+  }
 
   qrmi_string_free(job_id);
 

--- a/src/cext.rs
+++ b/src/cext.rs
@@ -50,15 +50,9 @@ pub enum ReturnCode {
     TaskNotReadyError = 107,
     /// A required key was missing from a provider's environment variable map.
     MissingConfigKeyError = 108,
-    /// A vendor's API rejected a request as malformed after actually
-    /// receiving it, as opposed to `InvalidValueError`, which is rejected
-    /// locally before any request is sent.
-    InvalidRequestError = 109,
-    /// A value was invalid for a reason not covered by a more specific
-    /// code (this covers both a value QRMI itself rejected before making
-    /// any request, and a vendor-specific value like an unrecognized
-    /// program ID or device type).
-    InvalidValueError = 110,
+    /// A value was invalid, whether QRMI itself rejected it locally or a
+    /// vendor's API rejected the resulting request after receiving it.
+    InvalidInputError = 109,
     /// The named resource (e.g. a backend) does not exist.
     ResourceNotFoundError = 111,
     /// The named task (e.g. a job) does not exist, or has already been
@@ -80,8 +74,7 @@ impl From<QrmiErrorKind> for ReturnCode {
             QrmiErrorKind::ResourceNotFound => ReturnCode::ResourceNotFoundError,
             QrmiErrorKind::TaskNotFound => ReturnCode::TaskNotFoundError,
             QrmiErrorKind::AuthenticationFailed => ReturnCode::AuthenticationFailedError,
-            QrmiErrorKind::InvalidRequest => ReturnCode::InvalidRequestError,
-            QrmiErrorKind::InvalidValue => ReturnCode::InvalidValueError,
+            QrmiErrorKind::InvalidInput => ReturnCode::InvalidInputError,
             QrmiErrorKind::Other => ReturnCode::Error,
         }
     }

--- a/src/cext.rs
+++ b/src/cext.rs
@@ -50,9 +50,14 @@ pub enum ReturnCode {
     TaskNotReadyError = 107,
     /// A required key was missing from a provider's environment variable map.
     MissingConfigKeyError = 108,
-    /// A `filters` string was malformed or contained an invalid value.
-    InvalidFilterError = 109,
-    /// A value was invalid for a reason not covered by a more specific code.
+    /// A vendor's API rejected a request as malformed after actually
+    /// receiving it, as opposed to `InvalidValueError`, which is rejected
+    /// locally before any request is sent.
+    InvalidRequestError = 109,
+    /// A value was invalid for a reason not covered by a more specific
+    /// code (this covers both a value QRMI itself rejected before making
+    /// any request, and a vendor-specific value like an unrecognized
+    /// program ID or device type).
     InvalidValueError = 110,
     /// The named resource (e.g. a backend) does not exist.
     ResourceNotFoundError = 111,
@@ -75,7 +80,7 @@ impl From<QrmiErrorKind> for ReturnCode {
             QrmiErrorKind::ResourceNotFound => ReturnCode::ResourceNotFoundError,
             QrmiErrorKind::TaskNotFound => ReturnCode::TaskNotFoundError,
             QrmiErrorKind::AuthenticationFailed => ReturnCode::AuthenticationFailedError,
-            QrmiErrorKind::InvalidFilter => ReturnCode::InvalidFilterError,
+            QrmiErrorKind::InvalidRequest => ReturnCode::InvalidRequestError,
             QrmiErrorKind::InvalidValue => ReturnCode::InvalidValueError,
             QrmiErrorKind::Other => ReturnCode::Error,
         }
@@ -703,21 +708,24 @@ pub unsafe extern "C" fn qrmi_config_resource_names_get(
 /// # Example
 ///
 /// @code
-///   const char * last_error = qrmi_get_last_error();
+///   char * last_error = qrmi_get_last_error();
 ///   if (last_error != NULL) {
 ///     printf("last error = %s\n", last_error);
 ///     qrmi_string_free(last_error);
 ///   }
 /// @endcode
 ///
-/// @return message text of the most recent error
+/// @return message text of the most recent error. The caller takes
+/// ownership of the returned string and must release it with
+/// `qrmi_string_free()` once done with it (or it will leak). Returns NULL
+/// if no error has been recorded yet.
 /// @version 0.8.0
 #[no_mangle]
-pub unsafe extern "C" fn qrmi_get_last_error() -> *const c_char {
+pub unsafe extern "C" fn qrmi_get_last_error() -> *mut c_char {
     crate::common::initialize();
     LAST_ERROR.with(|cell| match &*cell.borrow() {
         Some(cstr) => cstr.clone().into_raw(),
-        None => std::ptr::null(),
+        None => std::ptr::null_mut(),
     })
 }
 
@@ -1726,9 +1734,9 @@ pub struct ResourceProvider {
 ///   QrmiResourceDef *def = qrmi_config_resource_def_get(config, "ibm_inst1");
 ///   QrmiResourceProvider *provider = qrmi_provider_new(def->type, &def->environments);
 ///   if (provider == NULL) {
-///     const char *err = qrmi_get_last_error();
+///     char *err = qrmi_get_last_error();
 ///     printf("error: %s\n", err);
-///     qrmi_string_free((char *)err);
+///     qrmi_string_free(err);
 ///   }
 /// @endcode
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,23 +94,18 @@ pub enum QrmiError {
     #[error("authentication failed: {0}")]
     AuthenticationFailed(String),
 
-    /// A value read from configuration or supplied by the caller (a
-    /// `filters` string, a payload, ...) was invalid in a way QRMI itself
-    /// rejected before making any request -- as opposed to
-    /// [`QrmiError::InvalidRequest`], which is rejected by the vendor's API
-    /// after actually receiving it.
-    #[error("invalid value: {0}")]
-    InvalidValue(String),
-
-    /// A vendor's API rejected a request as malformed after actually
-    /// receiving it (e.g. HTTP 400/409/413/422) -- as opposed to
-    /// [`QrmiError::InvalidValue`], which is rejected locally, before any
-    /// request is sent. This distinction matters to callers: this kind
-    /// means the vendor itself didn't like the request, which may point to
-    /// a vendor-specific constraint or version skew rather than a plain
-    /// input mistake.
-    #[error("invalid request: {0}")]
-    InvalidRequest(String),
+    /// A value QRMI was given -- as a parameter (a `filters` string, a
+    /// payload, a program ID, ...) or ultimately rejected by a vendor's API
+    /// after actually receiving a request built from it -- was invalid.
+    /// Deliberately doesn't distinguish "QRMI rejected this locally, before
+    /// sending anything" from "the vendor's API rejected the request after
+    /// receiving it" (e.g. HTTP 400/409/413/422): both mean the same thing
+    /// to a caller -- the input was bad -- and in practice callers want to
+    /// handle both the same way, so splitting them into separate variants
+    /// only added a distinction to check for no corresponding difference in
+    /// what to do about it.
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 
     /// A payload, or a piece of it, was not valid JSON.
     #[error("invalid JSON: {0}")]
@@ -154,10 +149,9 @@ impl QrmiError {
             QrmiError::ResourceNotFound(_) => QrmiErrorKind::ResourceNotFound,
             QrmiError::TaskNotFound(_) => QrmiErrorKind::TaskNotFound,
             QrmiError::AuthenticationFailed(_) => QrmiErrorKind::AuthenticationFailed,
-            QrmiError::InvalidValue(_) => QrmiErrorKind::InvalidValue,
-            QrmiError::InvalidRequest(_) => QrmiErrorKind::InvalidRequest,
-            QrmiError::InvalidJson(_) => QrmiErrorKind::InvalidValue,
-            QrmiError::InvalidUtf8(_) => QrmiErrorKind::InvalidValue,
+            QrmiError::InvalidInput(_) => QrmiErrorKind::InvalidInput,
+            QrmiError::InvalidJson(_) => QrmiErrorKind::InvalidInput,
+            QrmiError::InvalidUtf8(_) => QrmiErrorKind::InvalidInput,
             QrmiError::Ibm(e) => e.kind(),
             QrmiError::Pasqal(e) => e.kind(),
             QrmiError::Other(_) => QrmiErrorKind::Other,
@@ -195,16 +189,10 @@ pub enum QrmiErrorKind {
     TaskNotFound,
     /// The request's credentials were missing or rejected.
     AuthenticationFailed,
-    /// A vendor's API rejected a request as malformed after actually
-    /// receiving it, as opposed to `InvalidValue`, which is rejected
-    /// locally before any request is sent.
-    InvalidRequest,
-    /// A value was invalid for a reason not covered by a more specific kind
-    /// (this covers both a value QRMI itself rejected before making any
-    /// request -- e.g. a malformed `filters` string, JSON, or UTF-8 -- and
-    /// a vendor-specific value like an unrecognized program ID or device
-    /// type).
-    InvalidValue,
+    /// A value QRMI was given was invalid, whether QRMI itself rejected it
+    /// locally or a vendor's API rejected the resulting request after
+    /// receiving it.
+    InvalidInput,
     /// Everything else (vendor API failures, I/O, ...).
     Other,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,10 +94,23 @@ pub enum QrmiError {
     #[error("authentication failed: {0}")]
     AuthenticationFailed(String),
 
-    /// A `filters` string passed to [`crate::ResourceProvider::resources`] was
-    /// malformed or contained an invalid value.
-    #[error("invalid filter: {0}")]
-    InvalidFilter(String),
+    /// A value read from configuration or supplied by the caller (a
+    /// `filters` string, a payload, ...) was invalid in a way QRMI itself
+    /// rejected before making any request -- as opposed to
+    /// [`QrmiError::InvalidRequest`], which is rejected by the vendor's API
+    /// after actually receiving it.
+    #[error("invalid value: {0}")]
+    InvalidValue(String),
+
+    /// A vendor's API rejected a request as malformed after actually
+    /// receiving it (e.g. HTTP 400/409/413/422) -- as opposed to
+    /// [`QrmiError::InvalidValue`], which is rejected locally, before any
+    /// request is sent. This distinction matters to callers: this kind
+    /// means the vendor itself didn't like the request, which may point to
+    /// a vendor-specific constraint or version skew rather than a plain
+    /// input mistake.
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
 
     /// A payload, or a piece of it, was not valid JSON.
     #[error("invalid JSON: {0}")]
@@ -141,7 +154,8 @@ impl QrmiError {
             QrmiError::ResourceNotFound(_) => QrmiErrorKind::ResourceNotFound,
             QrmiError::TaskNotFound(_) => QrmiErrorKind::TaskNotFound,
             QrmiError::AuthenticationFailed(_) => QrmiErrorKind::AuthenticationFailed,
-            QrmiError::InvalidFilter(_) => QrmiErrorKind::InvalidFilter,
+            QrmiError::InvalidValue(_) => QrmiErrorKind::InvalidValue,
+            QrmiError::InvalidRequest(_) => QrmiErrorKind::InvalidRequest,
             QrmiError::InvalidJson(_) => QrmiErrorKind::InvalidValue,
             QrmiError::InvalidUtf8(_) => QrmiErrorKind::InvalidValue,
             QrmiError::Ibm(e) => e.kind(),
@@ -181,9 +195,15 @@ pub enum QrmiErrorKind {
     TaskNotFound,
     /// The request's credentials were missing or rejected.
     AuthenticationFailed,
-    /// A `filters` string was malformed or contained an invalid value.
-    InvalidFilter,
-    /// A value was invalid for a reason not covered by a more specific kind.
+    /// A vendor's API rejected a request as malformed after actually
+    /// receiving it, as opposed to `InvalidValue`, which is rejected
+    /// locally before any request is sent.
+    InvalidRequest,
+    /// A value was invalid for a reason not covered by a more specific kind
+    /// (this covers both a value QRMI itself rejected before making any
+    /// request -- e.g. a malformed `filters` string, JSON, or UTF-8 -- and
+    /// a vendor-specific value like an unrecognized program ID or device
+    /// type).
     InvalidValue,
     /// Everything else (vendor API failures, I/O, ...).
     Other,

--- a/src/ibm/error.rs
+++ b/src/ibm/error.rs
@@ -38,8 +38,8 @@ pub enum IbmError {
 impl IbmError {
     pub(crate) fn kind(&self) -> QrmiErrorKind {
         match self {
-            IbmError::UnknownProgramId(_) => QrmiErrorKind::InvalidValue,
-            IbmError::InvalidSessionMode(_) => QrmiErrorKind::InvalidValue,
+            IbmError::UnknownProgramId(_) => QrmiErrorKind::InvalidInput,
+            IbmError::InvalidSessionMode(_) => QrmiErrorKind::InvalidInput,
         }
     }
 }
@@ -64,7 +64,7 @@ impl From<quantum_system_api::QuantumSystemError> for crate::QrmiError {
             QsError::BackendNotFound(msg) => crate::QrmiError::ResourceNotFound(msg),
             QsError::JobNotFound(msg) => crate::QrmiError::TaskNotFound(msg),
             QsError::AuthenticationFailed(msg) => crate::QrmiError::AuthenticationFailed(msg),
-            QsError::InvalidJobInput(msg) => crate::QrmiError::InvalidRequest(msg),
+            QsError::InvalidJobInput(msg) => crate::QrmiError::InvalidInput(msg),
             other => crate::QrmiError::Other(anyhow::Error::new(other)),
         }
     }

--- a/src/ibm/error.rs
+++ b/src/ibm/error.rs
@@ -64,6 +64,7 @@ impl From<quantum_system_api::QuantumSystemError> for crate::QrmiError {
             QsError::BackendNotFound(msg) => crate::QrmiError::ResourceNotFound(msg),
             QsError::JobNotFound(msg) => crate::QrmiError::TaskNotFound(msg),
             QsError::AuthenticationFailed(msg) => crate::QrmiError::AuthenticationFailed(msg),
+            QsError::InvalidJobInput(msg) => crate::QrmiError::InvalidRequest(msg),
             other => crate::QrmiError::Other(anyhow::Error::new(other)),
         }
     }

--- a/src/ibm/qiskit_runtime_service_provider/provider_filter.rs
+++ b/src/ibm/qiskit_runtime_service_provider/provider_filter.rs
@@ -76,27 +76,29 @@ impl BackendFilter {
                 continue;
             }
             let (key, value) = pair.split_once('=').ok_or_else(|| {
-                QrmiError::InvalidFilter(format!("invalid segment {pair:?}: expected 'key=value'"))
+                QrmiError::InvalidValue(format!(
+                    "invalid filter segment {pair:?}: expected 'key=value'"
+                ))
             })?;
             match key.trim() {
                 "num_qubits" => {
                     let n: u32 = value.trim().parse().map_err(|_| {
-                        QrmiError::InvalidFilter(format!(
-                            "invalid value for 'num_qubits': {value:?} (expected a non-negative integer)"
+                        QrmiError::InvalidValue(format!(
+                            "invalid value for filter 'num_qubits': {value:?} (expected a non-negative integer)"
                         ))
                     })?;
                     f.num_qubits = Some(n);
                 }
                 "max_shots" => {
                     f.max_shots = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidFilter(format!(
-                            "invalid value for 'max_shots': {value:?} (expected a non-negative integer)"
+                        QrmiError::InvalidValue(format!(
+                            "invalid value for filter 'max_shots': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "name" => {
                     let pattern = Pattern::new(value.trim()).map_err(|e| {
-                        QrmiError::InvalidFilter(format!(
+                        QrmiError::InvalidValue(format!(
                             "invalid glob pattern for 'name' filter {value:?}: {e}"
                         ))
                     })?;
@@ -107,8 +109,8 @@ impl BackendFilter {
                         "true" => true,
                         "false" => false,
                         _ => {
-                            return Err(QrmiError::InvalidFilter(format!(
-                                "invalid value for 'is_simulator': {value:?} (expected 'true' or 'false')"
+                            return Err(QrmiError::InvalidValue(format!(
+                                "invalid value for filter 'is_simulator': {value:?} (expected 'true' or 'false')"
                             )))
                         }
                     };
@@ -117,8 +119,8 @@ impl BackendFilter {
                     f.status = match value.trim() {
                         "online" => StatusFilter::Online,
                         _ => {
-                            return Err(QrmiError::InvalidFilter(format!(
-                                "invalid value for 'status': {value:?} (supported: 'online')"
+                            return Err(QrmiError::InvalidValue(format!(
+                                "invalid value for filter 'status': {value:?} (supported: 'online')"
                             )))
                         }
                     };

--- a/src/ibm/qiskit_runtime_service_provider/provider_filter.rs
+++ b/src/ibm/qiskit_runtime_service_provider/provider_filter.rs
@@ -76,14 +76,14 @@ impl BackendFilter {
                 continue;
             }
             let (key, value) = pair.split_once('=').ok_or_else(|| {
-                QrmiError::InvalidValue(format!(
+                QrmiError::InvalidInput(format!(
                     "invalid filter segment {pair:?}: expected 'key=value'"
                 ))
             })?;
             match key.trim() {
                 "num_qubits" => {
                     let n: u32 = value.trim().parse().map_err(|_| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid value for filter 'num_qubits': {value:?} (expected a non-negative integer)"
                         ))
                     })?;
@@ -91,14 +91,14 @@ impl BackendFilter {
                 }
                 "max_shots" => {
                     f.max_shots = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid value for filter 'max_shots': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "name" => {
                     let pattern = Pattern::new(value.trim()).map_err(|e| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid glob pattern for 'name' filter {value:?}: {e}"
                         ))
                     })?;
@@ -109,7 +109,7 @@ impl BackendFilter {
                         "true" => true,
                         "false" => false,
                         _ => {
-                            return Err(QrmiError::InvalidValue(format!(
+                            return Err(QrmiError::InvalidInput(format!(
                                 "invalid value for filter 'is_simulator': {value:?} (expected 'true' or 'false')"
                             )))
                         }
@@ -119,7 +119,7 @@ impl BackendFilter {
                     f.status = match value.trim() {
                         "online" => StatusFilter::Online,
                         _ => {
-                            return Err(QrmiError::InvalidValue(format!(
+                            return Err(QrmiError::InvalidInput(format!(
                                 "invalid value for filter 'status': {value:?} (supported: 'online')"
                             )))
                         }

--- a/src/ibm/quantum_compute_service_provider/provider_filter.rs
+++ b/src/ibm/quantum_compute_service_provider/provider_filter.rs
@@ -76,27 +76,29 @@ impl BackendFilter {
                 continue;
             }
             let (key, value) = pair.split_once('=').ok_or_else(|| {
-                QrmiError::InvalidFilter(format!("invalid segment {pair:?}: expected 'key=value'"))
+                QrmiError::InvalidValue(format!(
+                    "invalid filter segment {pair:?}: expected 'key=value'"
+                ))
             })?;
             match key.trim() {
                 "num_qubits" => {
                     let n: u32 = value.trim().parse().map_err(|_| {
-                        QrmiError::InvalidFilter(format!(
-                            "invalid value for 'num_qubits': {value:?} (expected a non-negative integer)"
+                        QrmiError::InvalidValue(format!(
+                            "invalid value for filter 'num_qubits': {value:?} (expected a non-negative integer)"
                         ))
                     })?;
                     f.num_qubits = Some(n);
                 }
                 "max_shots" => {
                     f.max_shots = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidFilter(format!(
-                            "invalid value for 'max_shots': {value:?} (expected a non-negative integer)"
+                        QrmiError::InvalidValue(format!(
+                            "invalid value for filter 'max_shots': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "name" => {
                     let pattern = Pattern::new(value.trim()).map_err(|e| {
-                        QrmiError::InvalidFilter(format!(
+                        QrmiError::InvalidValue(format!(
                             "invalid glob pattern for 'name' filter {value:?}: {e}"
                         ))
                     })?;
@@ -107,8 +109,8 @@ impl BackendFilter {
                         "true" => true,
                         "false" => false,
                         _ => {
-                            return Err(QrmiError::InvalidFilter(format!(
-                                "invalid value for 'is_simulator': {value:?} (expected 'true' or 'false')"
+                            return Err(QrmiError::InvalidValue(format!(
+                                "invalid value for filter 'is_simulator': {value:?} (expected 'true' or 'false')"
                             )))
                         }
                     };
@@ -117,8 +119,8 @@ impl BackendFilter {
                     f.status = match value.trim() {
                         "online" => StatusFilter::Online,
                         _ => {
-                            return Err(QrmiError::InvalidFilter(format!(
-                                "invalid value for 'status': {value:?} (supported: 'online')"
+                            return Err(QrmiError::InvalidValue(format!(
+                                "invalid value for filter 'status': {value:?} (supported: 'online')"
                             )))
                         }
                     };

--- a/src/ibm/quantum_compute_service_provider/provider_filter.rs
+++ b/src/ibm/quantum_compute_service_provider/provider_filter.rs
@@ -76,14 +76,14 @@ impl BackendFilter {
                 continue;
             }
             let (key, value) = pair.split_once('=').ok_or_else(|| {
-                QrmiError::InvalidValue(format!(
+                QrmiError::InvalidInput(format!(
                     "invalid filter segment {pair:?}: expected 'key=value'"
                 ))
             })?;
             match key.trim() {
                 "num_qubits" => {
                     let n: u32 = value.trim().parse().map_err(|_| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid value for filter 'num_qubits': {value:?} (expected a non-negative integer)"
                         ))
                     })?;
@@ -91,14 +91,14 @@ impl BackendFilter {
                 }
                 "max_shots" => {
                     f.max_shots = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid value for filter 'max_shots': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "name" => {
                     let pattern = Pattern::new(value.trim()).map_err(|e| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid glob pattern for 'name' filter {value:?}: {e}"
                         ))
                     })?;
@@ -109,7 +109,7 @@ impl BackendFilter {
                         "true" => true,
                         "false" => false,
                         _ => {
-                            return Err(QrmiError::InvalidValue(format!(
+                            return Err(QrmiError::InvalidInput(format!(
                                 "invalid value for filter 'is_simulator': {value:?} (expected 'true' or 'false')"
                             )))
                         }
@@ -119,7 +119,7 @@ impl BackendFilter {
                     f.status = match value.trim() {
                         "online" => StatusFilter::Online,
                         _ => {
-                            return Err(QrmiError::InvalidValue(format!(
+                            return Err(QrmiError::InvalidInput(format!(
                                 "invalid value for filter 'status': {value:?} (supported: 'online')"
                             )))
                         }

--- a/src/ibm/quantum_system_provider/provider_filter.rs
+++ b/src/ibm/quantum_system_provider/provider_filter.rs
@@ -80,26 +80,28 @@ impl BackendFilter {
                 continue;
             }
             let (key, value) = pair.split_once('=').ok_or_else(|| {
-                QrmiError::InvalidFilter(format!("invalid segment {pair:?}: expected 'key=value'"))
+                QrmiError::InvalidValue(format!(
+                    "invalid filter segment {pair:?}: expected 'key=value'"
+                ))
             })?;
             match key.trim() {
                 "num_qubits" => {
                     f.num_qubits = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidFilter(format!(
-                            "invalid value for 'num_qubits': {value:?} (expected a non-negative integer)"
+                        QrmiError::InvalidValue(format!(
+                            "invalid value for filter 'num_qubits': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "max_shots" => {
                     f.max_shots = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidFilter(format!(
-                            "invalid value for 'max_shots': {value:?} (expected a non-negative integer)"
+                        QrmiError::InvalidValue(format!(
+                            "invalid value for filter 'max_shots': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "name" => {
                     f.name_pattern = Some(Pattern::new(value.trim()).map_err(|e| {
-                        QrmiError::InvalidFilter(format!(
+                        QrmiError::InvalidValue(format!(
                             "invalid glob pattern for 'name' filter {value:?}: {e}"
                         ))
                     })?);
@@ -109,8 +111,8 @@ impl BackendFilter {
                         "true" => true,
                         "false" => false,
                         _ => {
-                            return Err(QrmiError::InvalidFilter(format!(
-                                "invalid value for 'is_simulator': {value:?} (expected 'true' or 'false')"
+                            return Err(QrmiError::InvalidValue(format!(
+                                "invalid value for filter 'is_simulator': {value:?} (expected 'true' or 'false')"
                             )))
                         }
                     };
@@ -119,8 +121,8 @@ impl BackendFilter {
                     f.status = match value.trim() {
                         "online" => StatusFilter::Online,
                         _ => {
-                            return Err(QrmiError::InvalidFilter(format!(
-                                "invalid value for 'status': {value:?} (supported: 'online')"
+                            return Err(QrmiError::InvalidValue(format!(
+                                "invalid value for filter 'status': {value:?} (supported: 'online')"
                             )))
                         }
                     };

--- a/src/ibm/quantum_system_provider/provider_filter.rs
+++ b/src/ibm/quantum_system_provider/provider_filter.rs
@@ -80,28 +80,28 @@ impl BackendFilter {
                 continue;
             }
             let (key, value) = pair.split_once('=').ok_or_else(|| {
-                QrmiError::InvalidValue(format!(
+                QrmiError::InvalidInput(format!(
                     "invalid filter segment {pair:?}: expected 'key=value'"
                 ))
             })?;
             match key.trim() {
                 "num_qubits" => {
                     f.num_qubits = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid value for filter 'num_qubits': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "max_shots" => {
                     f.max_shots = Some(value.trim().parse::<u64>().map_err(|_| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid value for filter 'max_shots': {value:?} (expected a non-negative integer)"
                         ))
                     })?);
                 }
                 "name" => {
                     f.name_pattern = Some(Pattern::new(value.trim()).map_err(|e| {
-                        QrmiError::InvalidValue(format!(
+                        QrmiError::InvalidInput(format!(
                             "invalid glob pattern for 'name' filter {value:?}: {e}"
                         ))
                     })?);
@@ -111,7 +111,7 @@ impl BackendFilter {
                         "true" => true,
                         "false" => false,
                         _ => {
-                            return Err(QrmiError::InvalidValue(format!(
+                            return Err(QrmiError::InvalidInput(format!(
                                 "invalid value for filter 'is_simulator': {value:?} (expected 'true' or 'false')"
                             )))
                         }
@@ -121,7 +121,7 @@ impl BackendFilter {
                     f.status = match value.trim() {
                         "online" => StatusFilter::Online,
                         _ => {
-                            return Err(QrmiError::InvalidValue(format!(
+                            return Err(QrmiError::InvalidInput(format!(
                                 "invalid value for filter 'status': {value:?} (supported: 'online')"
                             )))
                         }

--- a/src/iqm.rs
+++ b/src/iqm.rs
@@ -12,6 +12,7 @@
 
 //! QRMI implementations for IQM
 
+pub(crate) mod error;
 mod server;
 
 pub use self::server::IQMServer;

--- a/src/iqm/error.rs
+++ b/src/iqm/error.rs
@@ -50,7 +50,7 @@ pub(crate) enum ResourceKind {
 /// "the request itself was malformed" (`InvalidInput`, or -- for
 /// `job_submit` specifically -- one of `InvalidJobPayload` /
 /// `UnsupportedJobType` / `InvalidInput`), so it maps to
-/// [`QrmiError::InvalidRequest`]. 403, by contrast, means something
+/// [`QrmiError::InvalidInput`]. 403, by contrast, means something
 /// different per endpoint in this API -- e.g. `cancel_job_v1`'s 403 is
 /// `IllegalJobStatus` (the job's current state doesn't allow cancelling
 /// it), which has nothing to do with authentication -- so it's deliberately
@@ -73,7 +73,7 @@ where
     if let iqm_server_api::apis::Error::ResponseError(ref content) = err {
         let body = content.content.clone();
         match content.status {
-            StatusCode::BAD_REQUEST => return QrmiError::InvalidRequest(body),
+            StatusCode::BAD_REQUEST => return QrmiError::InvalidInput(body),
             StatusCode::UNAUTHORIZED => return QrmiError::AuthenticationFailed(body),
             StatusCode::NOT_FOUND => {
                 return match resource_kind {

--- a/src/iqm/error.rs
+++ b/src/iqm/error.rs
@@ -1,0 +1,83 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! Maps errors from `iqm_server_api` -- an OpenAPI-generated client we don't
+//! control or modify -- onto [`crate::QrmiError`].
+//!
+//! Unlike `quantum_system_client` (which we own, and so gave its own
+//! `thiserror`-based error type with the same kind of classification baked
+//! directly into it), `iqm_server_api` is generated code: every operation
+//! returns `Result<T, iqm_server_api::apis::Error<E>>`, where `E` is a
+//! *different, per-operation* enum (`GetJobV1Error`, `CancelJobV1Error`,
+//! ...) of named response models (`Unauthorized`, `JobNotFound`,
+//! `RateLimitExceeded`, ...). That per-operation typing is nice for anyone
+//! matching on a single specific call, but it means there's no one type to
+//! hang a shared classifier off of the way `QuantumSystemError::from_response`
+//! does. [`classify`] instead works off of
+//! [`iqm_server_api::apis::Error::ResponseError`]'s `status` field, which
+//! every operation's error carries regardless of `E` -- the same
+//! status-code-based approach, just implemented here (the consumer) instead
+//! of there (the generated crate).
+
+use crate::QrmiError;
+use http::StatusCode;
+
+/// Disambiguates a 404 from the IQM Server API: on its own, the status code
+/// doesn't say whether it was a job or a quantum computer that wasn't
+/// found.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResourceKind {
+    Backend,
+    Job,
+}
+
+/// Maps a failed `iqm_server_api` call onto [`QrmiError`]. `resource_kind`
+/// disambiguates a 404 (see [`ResourceKind`]).
+///
+/// Deliberately conservative about which statuses get their own variant:
+/// 401 is uniformly "the API token was missing or rejected" across every
+/// endpoint (`Unauthorized`, generated the same way everywhere), so it maps
+/// to [`QrmiError::AuthenticationFailed`]. 403, by contrast, means something
+/// different per endpoint in this API -- e.g. `cancel_job_v1`'s 403 is
+/// `IllegalJobStatus` (the job's current state doesn't allow cancelling
+/// it), which has nothing to do with authentication -- so it's deliberately
+/// left unclassified (falls through to [`QrmiError::Other`]) rather than
+/// guessing.
+///
+/// Transport-level failures (connection, TLS, JSON decoding, ...) have no
+/// status to classify by and always fall through to
+/// [`QrmiError::Other`] too, same as a status this function doesn't
+/// otherwise recognize -- still carrying the original error as `source` (it
+/// implements `std::error::Error` via `iqm_server_api`'s own generated
+/// impl), so nothing is lost for anyone inspecting the chain.
+pub(crate) fn classify<T>(
+    err: iqm_server_api::apis::Error<T>,
+    resource_kind: ResourceKind,
+) -> QrmiError
+where
+    T: std::fmt::Debug + Send + Sync + 'static,
+{
+    if let iqm_server_api::apis::Error::ResponseError(ref content) = err {
+        let body = content.content.clone();
+        match content.status {
+            StatusCode::UNAUTHORIZED => return QrmiError::AuthenticationFailed(body),
+            StatusCode::NOT_FOUND => {
+                return match resource_kind {
+                    ResourceKind::Backend => QrmiError::ResourceNotFound(body),
+                    ResourceKind::Job => QrmiError::TaskNotFound(body),
+                };
+            }
+            _ => {}
+        }
+    }
+    QrmiError::Other(anyhow::Error::new(err))
+}

--- a/src/iqm/error.rs
+++ b/src/iqm/error.rs
@@ -46,7 +46,11 @@ pub(crate) enum ResourceKind {
 /// Deliberately conservative about which statuses get their own variant:
 /// 401 is uniformly "the API token was missing or rejected" across every
 /// endpoint (`Unauthorized`, generated the same way everywhere), so it maps
-/// to [`QrmiError::AuthenticationFailed`]. 403, by contrast, means something
+/// to [`QrmiError::AuthenticationFailed`]. 400 is likewise consistently
+/// "the request itself was malformed" (`InvalidInput`, or -- for
+/// `job_submit` specifically -- one of `InvalidJobPayload` /
+/// `UnsupportedJobType` / `InvalidInput`), so it maps to
+/// [`QrmiError::InvalidRequest`]. 403, by contrast, means something
 /// different per endpoint in this API -- e.g. `cancel_job_v1`'s 403 is
 /// `IllegalJobStatus` (the job's current state doesn't allow cancelling
 /// it), which has nothing to do with authentication -- so it's deliberately
@@ -69,6 +73,7 @@ where
     if let iqm_server_api::apis::Error::ResponseError(ref content) = err {
         let body = content.content.clone();
         match content.status {
+            StatusCode::BAD_REQUEST => return QrmiError::InvalidRequest(body),
             StatusCode::UNAUTHORIZED => return QrmiError::AuthenticationFailed(body),
             StatusCode::NOT_FOUND => {
                 return match resource_kind {

--- a/src/iqm/server.rs
+++ b/src/iqm/server.rs
@@ -11,9 +11,9 @@
 // that they have been altered from the originals.
 
 use crate::error::{required_env, QrmiError};
+use crate::iqm::error::{classify, ResourceKind};
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use crate::{QuantumResource, Result};
-use anyhow::Context;
 use async_trait::async_trait;
 use iqm_server_api::apis::calibration_sets_api::{
     get_calibration_set_v1, get_dynamic_quantum_architecture_v1, get_quality_metrics_v1,
@@ -87,21 +87,20 @@ impl IQMServer {
     /// being folded into the same `null`.
     fn parse_optional_artifact<B, E>(
         result: std::result::Result<B, iqm_server_api::apis::Error<E>>,
-        artifact_type: &str,
-    ) -> anyhow::Result<Value>
+        resource_kind: ResourceKind,
+    ) -> Result<Value>
     where
         B: AsRef<[u8]>,
         E: std::fmt::Debug + Send + Sync + 'static,
     {
         match result {
-            Ok(bytes) => serde_json::from_slice::<Value>(bytes.as_ref())
-                .with_context(|| format!("'{artifact_type}' artifact is not valid JSON")),
+            Ok(bytes) => Ok(serde_json::from_slice::<Value>(bytes.as_ref())?),
             Err(iqm_server_api::apis::Error::ResponseError(resp))
                 if resp.status.as_u16() == 404 =>
             {
                 Ok(Value::Null)
             }
-            Err(e) => Err(e).with_context(|| format!("Failed to fetch '{artifact_type}'")),
+            Err(e) => Err(classify(e, resource_kind)),
         }
     }
 }
@@ -121,7 +120,7 @@ impl QuantumResource for IQMServer {
     async fn is_accessible(&mut self) -> Result<bool> {
         let health = get_qc_health_v1(&self.config, &self.backend_name)
             .await
-            .context("failed to get backend details")?;
+            .map_err(|e| classify(e, ResourceKind::Backend))?;
         Ok(health.healthy)
     }
 
@@ -158,7 +157,7 @@ impl QuantumResource for IQMServer {
                 Some(job),
             )
             .await
-            .context("failed to start task")?;
+            .map_err(|e| classify(e, ResourceKind::Backend))?;
             Ok(job.id.to_string())
         } else {
             Err(QrmiError::UnsupportedPayload(format!("{payload:?}")))
@@ -170,7 +169,7 @@ impl QuantumResource for IQMServer {
     async fn task_stop(&mut self, task_id: &str) -> Result<()> {
         cancel_job_v1(&self.config, task_id)
             .await
-            .with_context(|| format!("failed to cancel job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         Ok(())
     }
 
@@ -179,7 +178,7 @@ impl QuantumResource for IQMServer {
     async fn task_status(&mut self, task_id: &str) -> Result<TaskStatus> {
         let job = get_job_v1(&self.config, task_id, Some(true), Some(30))
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         match job.status {
             IqmServerJobStatus::Waiting => Ok(TaskStatus::Queued),
             IqmServerJobStatus::Processing => Ok(TaskStatus::Running),
@@ -203,22 +202,19 @@ impl QuantumResource for IQMServer {
     async fn task_result(&mut self, task_id: &str) -> Result<TaskResult> {
         let measurements = Self::parse_optional_artifact(
             job_get_artifacts(&self.config, task_id, "measurements").await,
-            "measurements",
-        )
-        .context("Failed to get 'measurements' artifact")?;
+            ResourceKind::Job,
+        )?;
         let measurement_counts = Self::parse_optional_artifact(
             job_get_artifacts(&self.config, task_id, "measurement_counts").await,
-            "measurement_counts",
-        )
-        .context("Failed to get 'measurement_counts' artifact")?;
+            ResourceKind::Job,
+        )?;
 
         let result = json!({
             "measurements": measurements,
             "measurement_counts": measurement_counts,
         });
 
-        let result_str =
-            serde_json::to_string_pretty(&result).context("Failed to serialize result")?;
+        let result_str = serde_json::to_string_pretty(&result)?;
         Ok(TaskResult { value: result_str })
     }
 
@@ -227,7 +223,7 @@ impl QuantumResource for IQMServer {
     async fn task_logs(&mut self, task_id: &str) -> Result<String> {
         let job = get_job_v1(&self.config, task_id, Some(true), Some(30))
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         let mut log = String::new();
         writeln!(log, "Timeline   :").unwrap();
         for event in &job.timeline {
@@ -273,24 +269,21 @@ impl QuantumResource for IQMServer {
             &self.calibration_set_id,
         )
         .await
-        .context("Failed to get dynamic_quantum_architecture")?;
+        .map_err(|e| classify(e, ResourceKind::Backend))?;
         let dynamic_quantum_architecture: serde_json::Value =
-            serde_json::from_slice(&dynamic_quantum_architecture)
-                .context("Failed to parse dynamic_quantum_architecture")?;
+            serde_json::from_slice(&dynamic_quantum_architecture)?;
 
         let calibration_set =
             get_calibration_set_v1(&self.config, &self.backend_name, &self.calibration_set_id)
                 .await
-                .context("Failed to get calibration_set")?;
-        let calibration_set: serde_json::Value =
-            serde_json::from_slice(&calibration_set).context("Failed to parse calibration_set")?;
+                .map_err(|e| classify(e, ResourceKind::Backend))?;
+        let calibration_set: serde_json::Value = serde_json::from_slice(&calibration_set)?;
 
         let quality_metrics =
             get_quality_metrics_v1(&self.config, &self.backend_name, &self.calibration_set_id)
                 .await
-                .context("Failed to get quality_metrics")?;
-        let quality_metrics: serde_json::Value =
-            serde_json::from_slice(&quality_metrics).context("Failed to parse quality_metrics")?;
+                .map_err(|e| classify(e, ResourceKind::Backend))?;
+        let quality_metrics: serde_json::Value = serde_json::from_slice(&quality_metrics)?;
 
         // Static, calibration-independent topology. Unlike the three
         // fields above, its absence (404) is expected on some Station
@@ -302,9 +295,8 @@ impl QuantumResource for IQMServer {
                 "static-quantum-architectures",
             )
             .await,
-            "static_quantum_architecture",
-        )
-        .context("Failed to get static_quantum_architecture")?;
+            ResourceKind::Backend,
+        )?;
 
         let resp = json!({
             "dynamic_quantum_architecture": dynamic_quantum_architecture,

--- a/src/iqm/server.rs
+++ b/src/iqm/server.rs
@@ -121,7 +121,7 @@ impl QuantumResource for IQMServer {
         let health = get_qc_health_v1(&self.config, &self.backend_name)
             .await
             .map_err(|e| classify(e, ResourceKind::Backend))?;
-        Ok(health.healthy)
+        Ok(health.health.healthy)
     }
 
     /// IQM Server has no session concept. This does not contact the
@@ -166,10 +166,31 @@ impl QuantumResource for IQMServer {
 
     /// Stops a running job.
     ///
+    /// Fetches the job's current status first, and only actually asks the
+    /// server to cancel it if that status is `Waiting` or `Processing` --
+    /// a job already in a terminal state (`Completed`/`Failed`/`Cancelled`)
+    /// can't be cancelled again, and the server rejects that with 403
+    /// (`IllegalJobStatus`, see `crate::iqm::error`'s docs on why that
+    /// status isn't otherwise classified). Mirrors
+    /// `crate::ibm::quantum_compute_service::QuantumComputeService::task_stop`'s
+    /// same guard for the same reason.
+    ///
+    /// The cancel call's own result is deliberately discarded, same as
+    /// that implementation: even after checking, the job could still
+    /// finish on its own in the moment between the status check and this
+    /// call, and that race isn't an error worth surfacing to the caller.
     async fn task_stop(&mut self, task_id: &str) -> Result<()> {
-        cancel_job_v1(&self.config, task_id)
+        let job = get_job_v1(&self.config, task_id, Some(true), Some(30))
             .await
             .map_err(|e| classify(e, ResourceKind::Job))?;
+        if matches!(
+            job.status,
+            IqmServerJobStatus::Waiting | IqmServerJobStatus::Processing
+        ) {
+            cancel_job_v1(&self.config, task_id)
+                .await
+                .map_err(|e| classify(e, ResourceKind::Job))?;
+        }
         Ok(())
     }
 

--- a/src/iqm/server.rs
+++ b/src/iqm/server.rs
@@ -121,7 +121,7 @@ impl QuantumResource for IQMServer {
         let health = get_qc_health_v1(&self.config, &self.backend_name)
             .await
             .map_err(|e| classify(e, ResourceKind::Backend))?;
-        Ok(health.health.healthy)
+        Ok(health.operational == "online" && health.health.healthy)
     }
 
     /// IQM Server has no session concept. This does not contact the

--- a/src/pasqal/error.rs
+++ b/src/pasqal/error.rs
@@ -37,8 +37,8 @@ pub enum PasqalError {
 impl PasqalError {
     pub(crate) fn kind(&self) -> QrmiErrorKind {
         match self {
-            PasqalError::InvalidDeviceType(_) => QrmiErrorKind::InvalidValue,
-            PasqalError::InvalidCudaqSequence(_) => QrmiErrorKind::InvalidValue,
+            PasqalError::InvalidDeviceType(_) => QrmiErrorKind::InvalidInput,
+            PasqalError::InvalidCudaqSequence(_) => QrmiErrorKind::InvalidInput,
         }
     }
 }

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -69,9 +69,21 @@ create_exception!(
 );
 create_exception!(
     qrmi._core,
-    InvalidFilterError,
+    InvalidValueError,
     QrmiError_,
-    "A `filters` string was malformed or contained an invalid value."
+    "A value was invalid for a reason not covered by a more specific \\
+     exception (this covers both a value QRMI itself rejected before \\
+     making any request -- e.g. a malformed `filters` string, JSON, or \\
+     UTF-8 -- and a vendor-specific value like an unrecognized program ID \\
+     or device type)."
+);
+create_exception!(
+    qrmi._core,
+    InvalidRequestError,
+    QrmiError_,
+    "A vendor's API rejected a request as malformed after actually \\
+     receiving it, as opposed to `InvalidValueError`, which is rejected \\
+     locally before any request is sent."
 );
 create_exception!(
     qrmi._core,
@@ -103,9 +115,8 @@ fn to_py_err(err: QrmiError) -> PyErr {
         QrmiErrorKind::UnsupportedResourceType => UnsupportedResourceTypeError::new_err(msg),
         QrmiErrorKind::UnsupportedPayload => UnsupportedPayloadError::new_err(msg),
         QrmiErrorKind::TaskNotReady => TaskNotReadyError::new_err(msg),
-        QrmiErrorKind::InvalidFilter | QrmiErrorKind::InvalidValue => {
-            InvalidFilterError::new_err(msg)
-        }
+        QrmiErrorKind::InvalidValue => InvalidValueError::new_err(msg),
+        QrmiErrorKind::InvalidRequest => InvalidRequestError::new_err(msg),
         QrmiErrorKind::ResourceNotFound => ResourceNotFoundError::new_err(msg),
         QrmiErrorKind::TaskNotFound => TaskNotFoundError::new_err(msg),
         QrmiErrorKind::AuthenticationFailed => AuthenticationFailedError::new_err(msg),
@@ -764,9 +775,10 @@ fn qrmi(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.py().get_type::<UnsupportedPayloadError>(),
     )?;
     m.add("TaskNotReadyError", m.py().get_type::<TaskNotReadyError>())?;
+    m.add("InvalidValueError", m.py().get_type::<InvalidValueError>())?;
     m.add(
-        "InvalidFilterError",
-        m.py().get_type::<InvalidFilterError>(),
+        "InvalidRequestError",
+        m.py().get_type::<InvalidRequestError>(),
     )?;
     m.add(
         "ResourceNotFoundError",

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -69,21 +69,11 @@ create_exception!(
 );
 create_exception!(
     qrmi._core,
-    InvalidValueError,
+    InvalidInputError,
     QrmiError_,
-    "A value was invalid for a reason not covered by a more specific \\
-     exception (this covers both a value QRMI itself rejected before \\
-     making any request -- e.g. a malformed `filters` string, JSON, or \\
-     UTF-8 -- and a vendor-specific value like an unrecognized program ID \\
-     or device type)."
-);
-create_exception!(
-    qrmi._core,
-    InvalidRequestError,
-    QrmiError_,
-    "A vendor's API rejected a request as malformed after actually \\
-     receiving it, as opposed to `InvalidValueError`, which is rejected \\
-     locally before any request is sent."
+    "A value QRMI was given was invalid, whether QRMI itself rejected it \\
+     locally (e.g. a malformed `filters` string, JSON, or UTF-8) or a \\
+     vendor's API rejected the resulting request after receiving it."
 );
 create_exception!(
     qrmi._core,
@@ -115,8 +105,7 @@ fn to_py_err(err: QrmiError) -> PyErr {
         QrmiErrorKind::UnsupportedResourceType => UnsupportedResourceTypeError::new_err(msg),
         QrmiErrorKind::UnsupportedPayload => UnsupportedPayloadError::new_err(msg),
         QrmiErrorKind::TaskNotReady => TaskNotReadyError::new_err(msg),
-        QrmiErrorKind::InvalidValue => InvalidValueError::new_err(msg),
-        QrmiErrorKind::InvalidRequest => InvalidRequestError::new_err(msg),
+        QrmiErrorKind::InvalidInput => InvalidInputError::new_err(msg),
         QrmiErrorKind::ResourceNotFound => ResourceNotFoundError::new_err(msg),
         QrmiErrorKind::TaskNotFound => TaskNotFoundError::new_err(msg),
         QrmiErrorKind::AuthenticationFailed => AuthenticationFailedError::new_err(msg),
@@ -775,11 +764,7 @@ fn qrmi(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.py().get_type::<UnsupportedPayloadError>(),
     )?;
     m.add("TaskNotReadyError", m.py().get_type::<TaskNotReadyError>())?;
-    m.add("InvalidValueError", m.py().get_type::<InvalidValueError>())?;
-    m.add(
-        "InvalidRequestError",
-        m.py().get_type::<InvalidRequestError>(),
-    )?;
+    m.add("InvalidInputError", m.py().get_type::<InvalidInputError>())?;
     m.add(
         "ResourceNotFoundError",
         m.py().get_type::<ResourceNotFoundError>(),


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
@yoonho This PR addresses IQM QRMI changes to add more typed error for openQSE comments. Could you please review and approve. Thanks,

### Summary

Extends the typed-error work done in #212  (`quantum_system_client`) to the IQM backend, and along the way simplifies `QrmiError`'s taxonomy: what were three separate "something was invalid" variants (`InvalidFilter`,
`InvalidValue`, and a short-lived `InvalidRequest`) are consolidated into one `QrmiError::InvalidInput`. While testing this against a live server, also found and fixed two pre-existing bugs unrelated to error classification: a response-shape mismatch in the generated `get_qc_health_v1` client, and `task_stop` unconditionally trying to cancel jobs that had already finished.

### Motivation

`src/iqm/server.rs` wrapped every call into `iqm_server_api` with `anyhow::Context`, so every IQM failure surfaced as `QrmiError::Other` regardless of cause -- a 401 looked the same as a 404 or a network timeout. Unlike `quantum_system_client` (#212 ), `iqm_server_api` is OpenAPI-generated code we don't own or modify, so it needed a different approach.

Separately, while wiring that up, it became clear that `QrmiError` had accumulated more granularity than it needed: `InvalidFilter` (a malformed `filters` string), `InvalidValue` (JSON/UTF-8/vendor-specific bad values), and `InvalidRequest` (a vendor's API rejecting a request after receiving it) all meant the same thing to a caller -- "the input was bad" -- and in practice a caller ends up checking for all of them together anyway. They're now one variant.

### What changed

#### IQM error classification (`src/iqm/error.rs`, new)
- `iqm_server_api` generates a *different* error enum per operation (`GetJobV1Error`, `CancelJobV1Error`, ...), so there's no single type to hang a shared classifier off of the way `quantum_system_client` could. `classify::<T>()` instead works off `Error::ResponseError`'s `status` field, which every operation's error carries regardless of the per-operation type `T`.
- Maps HTTP status code:
  -  401 → `AuthenticationFailed` (uniform across every endpoint -- always the `Unauthorized` model)
  -  400 → `InvalidInput` (uniform too -- `InvalidInput`, or for `job_submit` specifically one of  `InvalidJobPayload`/`UnsupportedJobType`/`InvalidInput`)
  -  404 → `ResourceNotFound`/`TaskNotFound` depending on a `ResourceKind` parameter passed at each call site (the status code alone doesn't say whether it was a job or a quantum computer that wasn't found).
- Deliberately does *not* classify 403: it means something different per endpoint in this API (e.g. `cancel_job_v1`'s 403 is `IllegalJobStatus` -- the job's state doesn't allow cancelling it, nothing to do with auth), so guessing would be wrong more often than not. Falls through to `Other`, still carrying the original error (with full `source()` chain) rather
  than losing it.
- `src/iqm/server.rs`: every `.context(...)?`/`.with_context(...)?` replaced with `.map_err(|e| classify(e, ResourceKind::...))?`; JSON-decode failures now go through the existing `QrmiError::InvalidJson` via a bare `?`
  instead of `anyhow::Context`, since that no longer needs a message wrapper.

#### `QrmiError` taxonomy cleanup (`src/error.rs`)
- `InvalidFilter`, `InvalidValue`, and `InvalidRequest` are gone; everything that used to construct one of them now constructs `QrmiError::InvalidInput(String)`, with a single `QrmiErrorKind::InvalidInput`.
- `quantum_system_client::QuantumSystemError::InvalidJobInput` (400/409/413/422, from #212 ) now maps to `QrmiError::InvalidInput` via `ibm/error.rs` -- previously it fell through to `Other` unnoticed.
- `IbmError::UnknownProgramId`/`InvalidSessionMode` and  `PasqalError::InvalidDeviceType`/`InvalidCudaqSequence` still exist as their own vendor-level variants (Rust-level matching stays precise), but now tag as `QrmiErrorKind::InvalidInput` like everything else.
- `InvalidJson`/`InvalidUtf8` are unchanged as distinct `QrmiError` variants (they need to stay separate for their `#[from]` conversions to work with `?`), but also now tag as `InvalidInput`.

#### C and Python bindings
- `cext.rs`: `ReturnCode::InvalidRequestError`/`InvalidValueError` (109/110, introduced earlier in this same line of work) collapse into a single `InvalidInputError` (109); 110 is retired rather than reused, since nothing has shipped against these codes yet.
- `pyext.rs`: `qrmi.InvalidFilterError`/`InvalidValueError`/`InvalidRequestError` collapse into `qrmi.InvalidInputError`, registered in both `to_py_err()` and the module's `m.add(...)` calls.

#### Two bugs found while testing against a live server

Wiring up real error classification meant actually exercising every code path against a live IQM Server instance, which surfaced two pre-existing bugs unrelated to error handling itself:

- **`get_qc_health_v1`'s response shape didn't match the live server(Seems recently changed..).**
  The generated `IqmServerQcHealthStatus` model expected a flat  `{"healthy": ..., "updated_at": ...}` body, but the server actually returns `{"operational": "...", "health": {"healthy": ..., "updated_at": ...}}` -- `healthy` one level deeper than the generated client expects. `is_accessible()` was failing outright with a `missing field 'healthy'`
  deserialization error as a result. Since `dependencies/iqm_client` is generated code, hand-patched `IqmServerQcHealthStatus` (adding a new nested `QcHealthDetail` struct for the `health` object) rather than
  editing `get_qc_health_v1` itself, which deserializes the whole response directly into that struct and so didn't need to change. The patch is flagged in a doc comment as something to drop once the crate is regenerated from a spec that reflects the server's current shape. `is_accessible()` updated accordingly (`health.healthy` →
  `health.health.healthy`).
- **`task_stop` unconditionally tried to cancel every job**, including ones that had already reached a terminal state, which the server correctly rejects with 403 (`IllegalJobStatus`) -- visible as log noise in the C example even though the example itself ignored the return code. Fixed at the library level (not just the example) to match `crate::ibm::quantum_compute_service::QuantumComputeService::task_stop`'s existing pattern: fetch the job's current status first, and only call `cancel_job_v1` if it's still `Waiting` or `Processing`. Unlike that existing implementation, this one does *not* discard the cancel call's own error: having just confirmed the job was cancellable, a failure at  that point is more likely a genuine problem (auth, network, a server error) than the job finishing in the split second between the check and the call, and swallowing a real failure would leave the caller believing the job was stopped when it wasn't.

### Backward compatibility

None of this has shipped yet, so return codes were renumbered/retired directly rather than leaving gaps for compatibility (109 is reused for the merged code; 110 is simply unused now). No other `QrmiError`/`ReturnCode`/
exception outside what's listed above changed.

### Testing

- `cargo clippy --release` and `cargo clippy --release --features=pyo3`
- `cargo build --release`
- `maturin build --release`
- Manual testing against a live IQM Server backend: invalid API token → 401
  → `AuthenticationFailed`; malformed job payload → 400 → `InvalidInput`;
  unknown job ID → 404 → `TaskNotFound`.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
