### PR TITLE
[IBM] Classify Qiskit Runtime API errors (Qiskit Runtime Service and Quantum Compute Service)

### DIFF
--- a/examples/qrmi/c/ibm_quantum_compute_service/src/quantum_compute_service.c
+++ b/examples/qrmi/c/ibm_quantum_compute_service/src/quantum_compute_service.c
@@ -30,11 +30,12 @@ int main(int argc, char *argv[]) {
 
   load_dotenv();
 
-  QrmiQuantumResource *qrmi =
-      qrmi_resource_new(argv[1], QRMI_RESOURCE_TYPE_IBM_QUANTUM_COMPUTE_SERVICE);
+  QrmiQuantumResource *qrmi = qrmi_resource_new(
+      argv[1], QRMI_RESOURCE_TYPE_IBM_QUANTUM_COMPUTE_SERVICE);
   if (!qrmi) {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "Failed to create QRMI for %s. %s\n", argv[1], last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to create QRMI for %s. %s (%d)\n", argv[1],
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     return EXIT_FAILURE;
   }
@@ -46,8 +47,10 @@ int main(int argc, char *argv[]) {
     QrmiResourceType resource_type;
     rc = qrmi_resource_type(qrmi, &resource_type);
     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-      const char *resource_type_str = qrmi_config_resource_type_to_str(resource_type);
-      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id, resource_type_str);
+      const char *resource_type_str =
+          qrmi_config_resource_type_to_str(resource_type);
+      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id,
+              resource_type_str);
     }
     qrmi_string_free(resource_id);
   }
@@ -60,8 +63,9 @@ int main(int argc, char *argv[]) {
       goto error;
     }
   } else {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s\n", last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s (%d)\n",
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     goto error;
   }
@@ -69,8 +73,9 @@ int main(int argc, char *argv[]) {
   char *acquisition_token = NULL;
   rc = qrmi_resource_acquire(qrmi, &acquisition_token);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "qrmi_resource_acquire() failed. %s\n", last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "qrmi_resource_acquire() failed. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     goto error;
   }
@@ -96,7 +101,10 @@ int main(int argc, char *argv[]) {
   char *job_id = NULL;
   rc = qrmi_resource_task_start(qrmi, &payload, &job_id);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    fprintf(stderr, "failed to start a task.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "failed to start a task. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
     free((void *)input);
     goto error;
   }
@@ -136,7 +144,10 @@ int main(int argc, char *argv[]) {
     fprintf(stdout, "%s\n", logs);
     qrmi_string_free(logs);
   } else {
-    fprintf(stderr, "Failed to retrieve job logs.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to retrieve job logs. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
   }
 
   qrmi_resource_task_stop(qrmi, job_id);
@@ -144,7 +155,12 @@ int main(int argc, char *argv[]) {
   qrmi_string_free((char *)job_id);
 
   rc = qrmi_resource_release(qrmi, acquisition_token);
-  fprintf(stdout, "qrmi_resource_release rc = %d\n", rc);
+  if (rc != QRMI_RETURN_CODE_SUCCESS) {
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to release a resource. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
+  }
   qrmi_string_free((char *)acquisition_token);
 
   qrmi_resource_free(qrmi);

--- a/src/ibm/error.rs
+++ b/src/ibm/error.rs
@@ -15,7 +15,8 @@
 //! generic across every vendor. Values of this type reach callers wrapped in
 //! `QrmiError::Ibm(_)` via `?` (see the `#[from]` on that variant).
 
-use crate::error::QrmiErrorKind;
+use crate::error::{QrmiError, QrmiErrorKind};
+use http::StatusCode;
 use thiserror::Error;
 
 /// Errors that only make sense in the context of IBM's backends (IBM Quantum
@@ -68,4 +69,78 @@ impl From<quantum_system_api::QuantumSystemError> for crate::QrmiError {
             other => crate::QrmiError::Other(anyhow::Error::new(other)),
         }
     }
+}
+
+/// Disambiguates a 404 from `quantum_compute_client` (used by
+/// [`crate::ibm::IBMQiskitRuntimeService`] and
+/// [`crate::ibm::IBMQuantumComputeService`]): on its own, the status code
+/// doesn't say whether it was a job, a session, or a backend that wasn't
+/// found.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResourceKind {
+    Backend,
+    Job,
+    Session,
+}
+
+/// Maps a failed `quantum_compute_client` call onto [`QrmiError`].
+/// `resource_kind` disambiguates a 404 (see [`ResourceKind`]).
+///
+/// Unlike `iqm_server_api` (see [`crate::iqm::error`]), every operation in
+/// this API reuses the same generic error body model (`ListJobs400Response`
+/// -- just a `trace`/`errors` pair) regardless of status, rather than a
+/// distinct *named* model per status the way IQM's `Unauthorized`/
+/// `JobNotFound` were. So there's nothing in the type system here to
+/// confirm what a given status actually means beyond the bare status code
+/// itself.
+///
+/// Classified conservatively as a result: 400 is consistently "the request
+/// itself was malformed" (`InvalidInput` -- literally what the reused
+/// model's name suggests it was originally modeled for), 401 is
+/// consistently "credentials missing or rejected" (`AuthenticationFailed`),
+/// and 404 maps to `ResourceNotFound`/`TaskNotFound` for a
+/// [`ResourceKind::Backend`]/[`ResourceKind::Job`] respectively. A 404 for
+/// [`ResourceKind::Session`] falls through to the generic case below
+/// instead: a session isn't a compute resource the way a backend is, and
+/// `QrmiError` doesn't have a variant that means "this session/acquisition
+/// doesn't exist" -- forcing it into `ResourceNotFound` would misrepresent
+/// what was actually missing, so it's left unclassified rather than
+/// mislabeled. 403 shows up on almost every endpoint here too, right
+/// alongside 401 -- but with no distinguishing model, and IQM having
+/// already taught us not to assume 403 means "access denied" without real
+/// evidence (see [`crate::iqm::error`]'s docs), it's deliberately left
+/// unclassified rather than guessed at.
+///
+/// Falls through to [`QrmiError::Other`] for a status this function
+/// doesn't otherwise recognize (403 and a `Session` 404 included), or for
+/// a transport-level failure (connection, TLS, JSON decoding, ...) that
+/// has no status at all. Either way `err` is kept as `source`; for the
+/// former, the response body is also attached via `.context(...)`, since
+/// `Error<T>`'s own `Display` only shows the bare status (e.g. `"status
+/// code 403 Forbidden"`), dropping whatever the server actually said.
+pub(crate) fn classify<T>(
+    err: quantum_compute_client::apis::Error<T>,
+    resource_kind: ResourceKind,
+) -> QrmiError
+where
+    T: std::fmt::Debug + Send + Sync + 'static,
+{
+    if let quantum_compute_client::apis::Error::ResponseError(ref content) = err {
+        let status = content.status;
+        let body = content.content.clone();
+        match (status, resource_kind) {
+            (StatusCode::BAD_REQUEST, _) => return QrmiError::InvalidInput(body),
+            (StatusCode::UNAUTHORIZED, _) => return QrmiError::AuthenticationFailed(body),
+            (StatusCode::NOT_FOUND, ResourceKind::Backend) => {
+                return QrmiError::ResourceNotFound(body)
+            }
+            (StatusCode::NOT_FOUND, ResourceKind::Job) => return QrmiError::TaskNotFound(body),
+            _ => {
+                return QrmiError::Other(
+                    anyhow::Error::new(err).context(format!("response body: {status} {body}")),
+                );
+            }
+        }
+    }
+    QrmiError::Other(anyhow::Error::new(err))
 }

--- a/src/ibm/qiskit_runtime_service.rs
+++ b/src/ibm/qiskit_runtime_service.rs
@@ -12,7 +12,7 @@
 
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2025
+// (C) Copyright IBM 2025-2026
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/src/ibm/qiskit_runtime_service.rs
+++ b/src/ibm/qiskit_runtime_service.rs
@@ -23,13 +23,12 @@
 // that they have been altered from the originals.
 
 use crate::error::{required_env, QrmiError};
-use crate::ibm::error::IbmError;
+use crate::ibm::error::{classify, IbmError, ResourceKind};
 use crate::ibm::qiskit_runtime_service::models::{
     CreateJobRequestOneOfAllOfParams, EstimatorV2Input, NoiseLearnerInput, SamplerV2Input,
 };
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use crate::{QuantumResource, Result};
-use anyhow::Context;
 use log::error;
 use quantum_compute_client::apis::{auth, backends_api, configuration, jobs_api, sessions_api};
 use quantum_compute_client::models;
@@ -138,7 +137,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
         let status_response =
             backends_api::get_backend_status(&self.config, &self.backend_name, None)
                 .await
-                .context("failed to get backend status")?;
+                .map_err(|e| classify(e, ResourceKind::Backend))?;
         // Print the status, using "unknown" if no status is available
         let status_str = status_response
             .status
@@ -168,7 +167,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
         if let Some(existing_session_id) = self.session_id.clone() {
             let response = sessions_api::get_session(&self.config, &existing_session_id, None)
                 .await
-                .context("failed to get session")?;
+                .map_err(|e| classify(e, ResourceKind::Session))?;
             let active_ttl = response.active_ttl.unwrap_or(1);
             let max_ttl = response.max_ttl.unwrap_or(1);
 
@@ -196,7 +195,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
         let response =
             sessions_api::create_session(&self.config, None, Some(create_session_request))
                 .await
-                .context("failed to create session")?;
+                .map_err(|e| classify(e, ResourceKind::Session))?;
 
         self.session_id = Some(response.id.clone());
         Ok(response.id)
@@ -238,7 +237,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
             None,
         )
         .await
-        .context("failed to list jobs")?;
+        .map_err(|e| classify(e, ResourceKind::Session))?;
 
         if let Some(pending_jobs) = jobs_resp.jobs {
             if !pending_jobs.is_empty() {
@@ -253,7 +252,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
             // in the session appearing as “Cancelled” on the IQP web interface
             sessions_api::delete_session_close(&self.config, acquisition_token, None)
                 .await
-                .context("failed to close session")?;
+                .map_err(|e| classify(e, ResourceKind::Session))?;
         } else {
             // Close this session as is — the behavior is consistent with the implementation in qiskit-ibm-runtim.
             // Displays “Completed” on the IQP web.
@@ -264,7 +263,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
                 Some(models::UpdateSessionRequest::new(false)),
             )
             .await
-            .context("failed to update session")?;
+            .map_err(|e| classify(e, ResourceKind::Session))?;
         }
         self.session_id = None;
         Ok(())
@@ -323,7 +322,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
             ));
             let response = jobs_api::create_job(&self.config, None, None, Some(create_job_request))
                 .await
-                .context("failed to create job")?;
+                .map_err(|e| classify(e, ResourceKind::Backend))?;
 
             Ok(response.id)
         } else {
@@ -350,7 +349,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
         }
         let job_details = jobs_api::get_job(&self.config, task_id, None, None)
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         let status = job_details.status;
         if status == models::job_response::Status::Running
             || status == models::job_response::Status::Queued
@@ -380,7 +379,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
         }
         let job_details = jobs_api::get_job(&self.config, task_id, None, None)
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         let status = job_details.status;
         match status {
             models::job_response::Status::Running => Ok(TaskStatus::Running),
@@ -410,7 +409,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
         } // Check if the task is completed before fetching the results.
         let job_details = jobs_api::get_job(&self.config, task_id, None, None)
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         let status = job_details.status;
         if status != models::job_response::Status::Completed {
             return Err(QrmiError::TaskNotReady {
@@ -420,7 +419,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
         }
         let results = jobs_api::get_job_results_jid(&self.config, task_id, None)
             .await
-            .with_context(|| format!("failed to get results for job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         Ok(TaskResult { value: results })
     }
 
@@ -429,7 +428,7 @@ impl QuantumResource for IBMQiskitRuntimeService {
     async fn task_logs(&mut self, task_id: &str) -> Result<String> {
         let logs = jobs_api::get_job_logs_jid(&self.config, task_id, None)
             .await
-            .with_context(|| format!("failed to get logs for job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         Ok(logs)
     }
 

--- a/src/ibm/quantum_compute_service.rs
+++ b/src/ibm/quantum_compute_service.rs
@@ -12,13 +12,12 @@
 // that they have been altered from the originals.
 
 use crate::error::{required_env, QrmiError};
-use crate::ibm::error::IbmError;
+use crate::ibm::error::{classify, IbmError, ResourceKind};
 use crate::ibm::quantum_compute_service::models::{
     CreateJobRequestOneOfAllOfParams, EstimatorV2Input, NoiseLearnerInput, SamplerV2Input,
 };
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use crate::{QuantumResource, Result};
-use anyhow::Context;
 use log::error;
 use quantum_compute_client::apis::{auth, backends_api, configuration, jobs_api, sessions_api};
 use quantum_compute_client::models;
@@ -127,7 +126,7 @@ impl QuantumResource for IBMQuantumComputeService {
         let status_response =
             backends_api::get_backend_status(&self.config, &self.backend_name, None)
                 .await
-                .context("failed to get backend status")?;
+                .map_err(|e| classify(e, ResourceKind::Backend))?;
         // Print the status, using "unknown" if no status is available
         let status_str = status_response
             .status
@@ -157,7 +156,7 @@ impl QuantumResource for IBMQuantumComputeService {
         if let Some(existing_session_id) = self.session_id.clone() {
             let response = sessions_api::get_session(&self.config, &existing_session_id, None)
                 .await
-                .context("failed to get session")?;
+                .map_err(|e| classify(e, ResourceKind::Session))?;
             let active_ttl = response.active_ttl.unwrap_or(1);
             let max_ttl = response.max_ttl.unwrap_or(1);
 
@@ -185,7 +184,7 @@ impl QuantumResource for IBMQuantumComputeService {
         let response =
             sessions_api::create_session(&self.config, None, Some(create_session_request))
                 .await
-                .context("failed to create session")?;
+                .map_err(|e| classify(e, ResourceKind::Session))?;
 
         self.session_id = Some(response.id.clone());
         Ok(response.id)
@@ -227,7 +226,7 @@ impl QuantumResource for IBMQuantumComputeService {
             None,
         )
         .await
-        .context("failed to list jobs")?;
+        .map_err(|e| classify(e, ResourceKind::Session))?;
 
         if let Some(pending_jobs) = jobs_resp.jobs {
             if !pending_jobs.is_empty() {
@@ -242,7 +241,7 @@ impl QuantumResource for IBMQuantumComputeService {
             // in the session appearing as “Cancelled” on the IQP web interface
             sessions_api::delete_session_close(&self.config, acquisition_token, None)
                 .await
-                .context("failed to close session")?;
+                .map_err(|e| classify(e, ResourceKind::Session))?;
         } else {
             // Close this session as is — the behavior is consistent with the implementation in qiskit-ibm-runtim.
             // Displays “Completed” on the IQP web.
@@ -253,7 +252,7 @@ impl QuantumResource for IBMQuantumComputeService {
                 Some(models::UpdateSessionRequest::new(false)),
             )
             .await
-            .context("failed to update session")?;
+            .map_err(|e| classify(e, ResourceKind::Session))?;
         }
         self.session_id = None;
         Ok(())
@@ -312,7 +311,7 @@ impl QuantumResource for IBMQuantumComputeService {
             ));
             let response = jobs_api::create_job(&self.config, None, None, Some(create_job_request))
                 .await
-                .context("failed to create job")?;
+                .map_err(|e| classify(e, ResourceKind::Backend))?;
 
             Ok(response.id)
         } else {
@@ -339,7 +338,7 @@ impl QuantumResource for IBMQuantumComputeService {
         }
         let job_details = jobs_api::get_job(&self.config, task_id, None, None)
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         let status = job_details.status;
         if status == models::job_response::Status::Running
             || status == models::job_response::Status::Queued
@@ -369,7 +368,7 @@ impl QuantumResource for IBMQuantumComputeService {
         }
         let job_details = jobs_api::get_job(&self.config, task_id, None, None)
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         let status = job_details.status;
         match status {
             models::job_response::Status::Running => Ok(TaskStatus::Running),
@@ -399,7 +398,7 @@ impl QuantumResource for IBMQuantumComputeService {
         } // Check if the task is completed before fetching the results.
         let job_details = jobs_api::get_job(&self.config, task_id, None, None)
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         let status = job_details.status;
         if status != models::job_response::Status::Completed {
             return Err(QrmiError::TaskNotReady {
@@ -409,7 +408,7 @@ impl QuantumResource for IBMQuantumComputeService {
         }
         let results = jobs_api::get_job_results_jid(&self.config, task_id, None)
             .await
-            .with_context(|| format!("failed to get results for job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         Ok(TaskResult { value: results })
     }
 
@@ -418,7 +417,7 @@ impl QuantumResource for IBMQuantumComputeService {
     async fn task_logs(&mut self, task_id: &str) -> Result<String> {
         let logs = jobs_api::get_job_logs_jid(&self.config, task_id, None)
             .await
-            .with_context(|| format!("failed to get logs for job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         Ok(logs)
     }
 


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->

@OkuyanBoga @oscar-wallis @m-meller @jcornall STFC team,
Could you please review and approve this PR at your earliest convenience? This PR contains one of the recent typed error support changes. The implementation is relatively simple and only introduces a mapping from anyhow::Result to QrmiError. I am hoping to release this change as soon as possible. If you do not expect to have time to review it in the near future, please let me know. I will then explore alternative review arrangements, both for this PR and for future code reviews.

### Summary

Extends the typed-error classification work done for `quantum_system_client` (#212) and IQM (#213) to `quantum_compute_client` -- the OpenAPI-generated client shared by both `IBMQiskitRuntimeService` and
`IBMQuantumComputeService`. Both implementations wrapped every call with `anyhow::Context`, so every failure surfaced as `QrmiError::Other` regardless of cause; a 401 looked the same as a 404 or a network timeout.

### What changed

#### Shared classifier (`src/ibm/error.rs`)
- `quantum_compute_client` is OpenAPI-generated code we don't own or modify (same constraint as `iqm_server_api`), and -- unlike IQM -- every operation here reuses the *same* generic error body model
  (`ListJobs400Response`, just a `trace`/`errors` pair) regardless of status, rather than a distinct named model per status. There's nothing in the type system to confirm what a given status actually means beyond the bare code itself, so `classify::<T>()` works off `Error::ResponseError`'s `status` field the same way IQM's classifier does, but is more
  conservative about which statuses it's willing to name: 
  - 400 → `InvalidInput` (the reused model's own name suggests it was originally modeled for exactly this).
  - 401 → `AuthenticationFailed` (consistent across every endpoint). 
  - 404 → `ResourceNotFound`/`TaskNotFound`, disambiguated by a `ResourceKind` parameter (`Backend`/`Job`/`Session`) passed at each call site -- the status alone doesn't say which kind of thing was missing.
  - A `Session` 404 is deliberately left unclassified rather than forced into `ResourceNotFound`: a session isn't a compute resource the way a backend is, and `QrmiError` doesn't have a variant for "this session/acquisition doesn't exist," so mislabeling it seemed worse than leaving it generic.
  - 403 shows up on almost every endpoint here, right alongside 401 -- but with no distinguishing model, and IQM having already taught us not to assume 403 means "access denied" without real evidence, it's deliberately left unclassified too.
  - Everything unclassified (403, a `Session` 404, 409, 429, 500, ...) falls through to `QrmiError::Other`, but with the response body attached via `.context(...)` -- `Error<T>`'s own `Display` only shows the bare status (e.g. `"status code 403 Forbidden"`), dropping whatever the server actually said. `err` itself is kept as `source` either way, so nothing is lost for anyone inspecting the chain.

#### `src/ibm/qiskit_runtime_service.rs` / `src/ibm/quantum_compute_service.rs`
- Both files are near-identical (same underlying client, same operations), so the same 12 `.context(...)?`/`.with_context(...)?` call sites in each were replaced with `.map_err(|e| classify(e, ResourceKind::...))?`.
- No behavior changes beyond the error classification itself.

### Backward compatibility

Purely additive from a behavior standpoint: calls that previously succeeded still succeed the same way. Calls that previously failed still fail, just with a more specific `QrmiError` variant (and correspondingly more specific
`ReturnCode`/Python exception) instead of always `Other`. No new `QrmiError`/`ReturnCode`/exception variants were needed -- everything maps onto ones already introduced by the earlier IQM work #213 .

### Testing

- `cargo clippy --release` and `cargo clippy --release --features=pyo3`
- `cargo build --release`
- `maturin build --release`
- Manual testing against a live IBM Qiskit Runtime backend: <!-- fill in once testing is complete, e.g. invalid API key -> 401 -> AuthenticationFailed; unknown job ID -> 404 -> TaskNotFound -->

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
