### PR TITLE
[AnB] Classify Alice & Bob Felis API errors, fix several panics on bad input

### DIFF
--- a/examples/qrmi/c/alice_bob_felis/src/felis.c
+++ b/examples/qrmi/c/alice_bob_felis/src/felis.c
@@ -32,8 +32,9 @@ int main(int argc, char *argv[]) {
   QrmiQuantumResource *qrmi =
       qrmi_resource_new(argv[1], QRMI_RESOURCE_TYPE_ALICE_BOB_FELIS);
   if (!qrmi) {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "Failed to create QRMI for %s. %s\n", argv[1], last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "Failed to create QRMI for %s. %s (%d)\n", argv[1],
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     return EXIT_FAILURE;
   }
@@ -45,8 +46,10 @@ int main(int argc, char *argv[]) {
     QrmiResourceType resource_type;
     rc = qrmi_resource_type(qrmi, &resource_type);
     if (rc == QRMI_RETURN_CODE_SUCCESS) {
-      const char *resource_type_str = qrmi_config_resource_type_to_str(resource_type);
-      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id, resource_type_str);
+      const char *resource_type_str =
+          qrmi_config_resource_type_to_str(resource_type);
+      fprintf(stdout, "Selected resource: id=%s type=%s\n", resource_id,
+              resource_type_str);
     }
     qrmi_string_free(resource_id);
   }
@@ -59,8 +62,9 @@ int main(int argc, char *argv[]) {
       goto error;
     }
   } else {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s\n", last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "qrmi_resource_is_accessible() failed. %s (%d)\n",
+            last_error, qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     goto error;
   }
@@ -68,8 +72,9 @@ int main(int argc, char *argv[]) {
   char *acquisition_token = NULL;
   rc = qrmi_resource_acquire(qrmi, &acquisition_token);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    const char* last_error = qrmi_get_last_error();
-    fprintf(stdout, "qrmi_resource_acquire() failed. %s\n", last_error);
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stdout, "qrmi_resource_acquire() failed. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
     qrmi_string_free((char *)last_error);
     goto error;
   }
@@ -81,7 +86,10 @@ int main(int argc, char *argv[]) {
     fprintf(stdout, "target = %s\n", target);
     qrmi_string_free((char *)target);
   } else {
-    fprintf(stderr, "qrmi_resource_target() failed.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "qrmi_resource_target() failed. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
     goto error;
   }
 
@@ -96,9 +104,8 @@ int main(int argc, char *argv[]) {
   char input_json[128];
 
   snprintf(input_json, sizeof(input_json),
-          "{\"nbShots\": %d, \"averageNbPhotons\": %d}",
-          nbShots,
-          averageNbPhotons);
+           "{\"nbShots\": %d, \"averageNbPhotons\": %d}", nbShots,
+           averageNbPhotons);
 
   QrmiPayload payload;
   payload.tag = QRMI_PAYLOAD_ALICE_BOB_FELIS;
@@ -108,7 +115,10 @@ int main(int argc, char *argv[]) {
   char *job_id = NULL;
   rc = qrmi_resource_task_start(qrmi, &payload, &job_id);
   if (rc != QRMI_RETURN_CODE_SUCCESS) {
-    fprintf(stderr, "failed to start a task.\n");
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stderr, "failed to start a task. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
     free((void *)input);
     goto error;
   }
@@ -145,7 +155,12 @@ int main(int argc, char *argv[]) {
   qrmi_string_free((char *)job_id);
 
   rc = qrmi_resource_release(qrmi, acquisition_token);
-  fprintf(stdout, "qrmi_resource_release rc = %d\n", rc);
+  if (rc != QRMI_RETURN_CODE_SUCCESS) {
+    const char *last_error = qrmi_get_last_error();
+    fprintf(stdout, "qrmi_resource_release. %s (%d)\n", last_error,
+            qrmi_get_last_error_kind());
+    qrmi_string_free((char *)last_error);
+  }
   qrmi_string_free((char *)acquisition_token);
 
   qrmi_resource_free(qrmi);

--- a/src/alice_bob.rs
+++ b/src/alice_bob.rs
@@ -12,6 +12,7 @@
 
 //! QRMI implementation for Alice and Bob Felis
 
+pub(crate) mod error;
 mod felis;
 
 pub use self::felis::AliceBobFelis;

--- a/src/alice_bob/error.rs
+++ b/src/alice_bob/error.rs
@@ -1,0 +1,86 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright Alice and Bob 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! Maps errors from `alice_bob_felis` -- an OpenAPI-generated client we
+//! don't control or modify -- onto [`crate::QrmiError`]. Same approach as
+//! [`crate::ibm::error`]'s `classify` for `quantum_compute_client` (see
+//! that module's docs for the general shape); the specifics here differ
+//! because this API's own OpenAPI spec differs.
+
+use crate::QrmiError;
+use http::StatusCode;
+
+/// Disambiguates a 404 from `alice_bob_felis`: on its own, the status code
+/// doesn't say whether it was a job or a target (backend) that wasn't
+/// found.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResourceKind {
+    Backend,
+    Job,
+}
+
+/// Maps a failed `alice_bob_felis` call onto [`QrmiError`]. `resource_kind`
+/// disambiguates a 404 (see [`ResourceKind`]).
+///
+/// Every operation this crate uses only ever types a single status --
+/// 422 (`HttpValidationError`, FastAPI's standard request-validation
+/// failure response) -- in its generated per-operation error enum;
+/// nothing else has a typed model at all, typed *or* generic (unlike
+/// `quantum_compute_client`'s reused `ListJobs400Response` -- see
+/// [`crate::ibm::error`]'s docs). That's different from IQM's 403 case,
+/// though: there, a specific status had a *documented, differently-named*
+/// model proving it meant something else. Here there's simply no
+/// documentation either way for 401/404, so rather than assume the API
+/// deviates from standard HTTP semantics without evidence, this still
+/// classifies them the ordinary way. 403 gets the same conservative
+/// treatment as everywhere else in this codebase, though: with nothing to
+/// confirm what it means here, it's left unclassified rather than guessed
+/// at.
+///
+/// - 422 (and 400, in case a future spec update adds it) → `InvalidInput`.
+/// - 401 → `AuthenticationFailed`.
+/// - 404 → `ResourceNotFound`/`TaskNotFound` by `resource_kind`.
+/// - Everything else (403 included), and any transport-level failure
+///   (connection, TLS, JSON decoding, ...) → `QrmiError::Other`, with `err`
+///   kept as `source` either way. For a response with an unclassified
+///   status specifically, the body is also attached via `.context(...)`,
+///   since `Error<T>`'s own `Display` only shows the bare status (e.g.
+///   `"status code 403 Forbidden"`), dropping whatever the server actually
+///   said.
+pub(crate) fn classify<T>(
+    err: alice_bob_felis::apis::Error<T>,
+    resource_kind: ResourceKind,
+) -> QrmiError
+where
+    T: std::fmt::Debug + Send + Sync + 'static,
+{
+    if let alice_bob_felis::apis::Error::ResponseError(ref content) = err {
+        let status = content.status;
+        let body = content.content.clone();
+        match (status, resource_kind) {
+            (StatusCode::BAD_REQUEST, _) | (StatusCode::UNPROCESSABLE_ENTITY, _) => {
+                return QrmiError::InvalidInput(body)
+            }
+            (StatusCode::UNAUTHORIZED, _) => return QrmiError::AuthenticationFailed(body),
+            (StatusCode::NOT_FOUND, ResourceKind::Backend) => {
+                return QrmiError::ResourceNotFound(body)
+            }
+            (StatusCode::NOT_FOUND, ResourceKind::Job) => return QrmiError::TaskNotFound(body),
+            _ => {
+                return QrmiError::Other(
+                    anyhow::Error::new(err).context(format!("response body: {status} {body}")),
+                );
+            }
+        }
+    }
+    QrmiError::Other(anyhow::Error::new(err))
+}

--- a/src/alice_bob/felis.rs
+++ b/src/alice_bob/felis.rs
@@ -12,6 +12,7 @@
 
 //! QRMI implementation for Alice and Bob Felis
 
+use crate::alice_bob::error::{classify, ResourceKind};
 use crate::error::QrmiError;
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use crate::{QuantumResource, Result};
@@ -19,7 +20,6 @@ use alice_bob_felis::apis::{configuration, jobs_service, targets_service};
 use alice_bob_felis::helpers::decode_api_key;
 use alice_bob_felis::models;
 use alice_bob_felis::models::{create_external_job, EventType};
-use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::json;
 use std::collections::HashMap;
@@ -71,7 +71,7 @@ impl AliceBobFelis {
     pub async fn list_backends(&mut self) -> Result<Vec<String>> {
         let targets = targets_service::list_targets(&self.config)
             .await
-            .context("failed to list targets")?;
+            .map_err(|e| classify(e, ResourceKind::Backend))?;
         let names: Vec<String> = targets
             .iter()
             .map(|t| target_to_device(&t.name.clone()))
@@ -82,7 +82,7 @@ impl AliceBobFelis {
     async fn most_recent_event(&mut self, task_id: &str) -> Result<models::EventType> {
         let job = jobs_service::get_job(&self.config, task_id, None)
             .await
-            .with_context(|| format!("failed to get job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         // Can safely assume events is non-empty
         let event = job.events.last().unwrap().r#type;
         Ok(event)
@@ -143,10 +143,10 @@ impl QuantumResource for AliceBobFelis {
 
             let external_job = jobs_service::create_job(&self.config, job, None)
                 .await
-                .context("failed to create job")?;
+                .map_err(|e| classify(e, ResourceKind::Backend))?;
             jobs_service::upload_input(&self.config, &external_job.id, human_qir, None)
                 .await
-                .context("failed to upload job input")?;
+                .map_err(|e| classify(e, ResourceKind::Job))?;
             // If here we can assume all went well
             Ok(external_job.id)
         } else {
@@ -160,7 +160,7 @@ impl QuantumResource for AliceBobFelis {
         if *event != EventType::Succeeded && *event != EventType::Cancelled {
             jobs_service::cancel_job(&self.config, task_id, None)
                 .await
-                .with_context(|| format!("failed to cancel job {task_id}"))?;
+                .map_err(|e| classify(e, ResourceKind::Job))?;
         }
         Ok(())
     }
@@ -189,7 +189,7 @@ impl QuantumResource for AliceBobFelis {
     async fn task_result(&mut self, task_id: &str) -> Result<TaskResult> {
         let output_csv = jobs_service::download_output(&self.config, task_id, None)
             .await
-            .with_context(|| format!("failed to download output for job {task_id}"))?;
+            .map_err(|e| classify(e, ResourceKind::Job))?;
         Ok(TaskResult { value: output_csv })
     }
 
@@ -201,7 +201,7 @@ impl QuantumResource for AliceBobFelis {
     async fn target(&mut self) -> Result<Target> {
         let targets = targets_service::list_targets(&self.config)
             .await
-            .context("failed to list targets")?;
+            .map_err(|e| classify(e, ResourceKind::Backend))?;
 
         let target = targets
             .iter()


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
@machjn Could you please review and approve this PR at your earliest convenience? This PR contains one of the recent typed error support changes. The implementation is relatively simple and only introduces a mapping from anyhow::Result to QrmiError. I am hoping to release this change as soon as possible. If you do not expect to have time to review it in the near future, please let me know. 

I have not yet tested this in a production environment. While I have confirmed that a properly typed error is returned when the required environment variables are missing, I would appreciate it if you could help validate the implementation on an actual system. In particular, it would be helpful to verify how it behaves in cases such as authentication failures, missing resources, and missing tasks. Thanks,

@awennersteen @OkuyanBoga You don't need to review this PR.

### Summary

Extends the typed-error classification work done for `quantum_system_client` (#212), IQM (#213 ), and `quantum_compute_client` (#214 ) to `alice_bob_felis` -- the OpenAPI-generated client used by `AliceBobFelis`.
Also fixes four places that could panic on ordinary bad input (a malformed API key, invalid JSON in a job payload, an unmatched target, and an unexpected empty response) rather than returning a proper `QrmiError`.

### What changed

#### Error classification (`src/alice_bob/error.rs`, new)
- Same general approach as [`crate::ibm::error`]'s classifier for `quantum_compute_client` (#214 ) : `alice_bob_felis` is OpenAPI-generated code we don't own or modify, so `classify::<T>()` works off `Error::ResponseError`'s `status` field rather than anything specific to this crate's generated code.
- This API's spec types even less than `quantum_compute_client`'s did: every operation this crate uses only ever types a single status -- 422 (`HttpValidationError`, FastAPI's standard validation-failure response) -- with nothing else having a typed model at all, generic or otherwise. That's different from IQM's 403 case, where a specific status had a *documented, differently-named* model proving it meant something else entirely; here there's simply no documentation either way for 401/404. Rather than assume the API deviates from ordinary HTTP semantics without evidence, 401 and 404 are still classified the standard way. 403 gets the same conservative treatment as everywhere else in this line of work, though: with nothing to confirm what it means here, it's left unclassified.
- Maps: 400/422 → `InvalidInput`; 401 → `AuthenticationFailed`; 404 → `ResourceNotFound`/`TaskNotFound`, disambiguated by a `ResourceKind` parameter (`Backend`/`Job`) passed at each call site. Everything else (403 included) falls through to `QrmiError::Other`, with the response body attached via `.context(...)` since `Error<T>`'s own `Display` only shows the bare status.
- `src/alice_bob/felis.rs`: all 7 `.context(...)?`/`.with_context(...)?` call sites replaced with `.map_err(|e| classify(e, ResourceKind::...))?`.

#### Panics on bad input (`src/alice_bob/felis.rs`)
Found while reviewing the file for this change:
- `AliceBobFelis::new()`: a malformed `..._QRMI_AB_FELIS_API_KEY` crashed the process via `decode_api_key(...).unwrap()`, even though `new()` already returns `Result<Self>`. Now returns `QrmiError::InvalidInput`.
- `task_start()`: malformed JSON in the job payload crashed the process via `serde_json::from_str(...).unwrap()`. Replaced with a bare `?`, which goes through the existing `QrmiError::InvalidJson` (`#[from]
  serde_json::Error`) -- no new variant needed.
- `target()`: no target matching the configured backend name crashed the process via `.expect(...)`. Now returns `QrmiError::ResourceNotFound`.
- `most_recent_event()`: an empty `events` list on a job crashed the process via `.unwrap()` on a comment-only assumption ("can safely assume events is non-empty"). Now returns `QrmiError::Other` instead of trusting
  that assumption unconditionally -- similar in spirit to the `get_qc_health_v1` response-shape issue found during the IQM work (#213 ):  trusting a vendor response to always have a certain shape without actually checking.

One remaining `.unwrap()` (`serde_json::to_string(&target).unwrap()` in `target()`) was left as-is: it's serializing our own already-typed internal data back to JSON, not anything a caller or vendor response controls, so it's not in the same category as the four above.

### Backward compatibility

Purely additive from a behavior standpoint: calls that previously succeeded still succeed the same way. Calls that previously failed with a generic `Other` now fail with a more specific `QrmiError` variant where classifiable. The four panic fixes change crash-the-process behavior into a normal `Err` return -- a behavior change, but one that only affects callers who were previously getting a panic (i.e., there's no "successful" behavior being altered). No new QrmiError`/`ReturnCode`/exception variants were needed -- everything maps onto ones already introduced by the earlier IQM work.

### Testing

- `cargo clippy --release` and `cargo clippy --release --features=pyo3`
- `cargo build --release`
- `maturin build --release`

## Checklist ✅

- [ ] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
