### PR TITLE
CI/Lychee - Mitigate timeout errors

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -15,6 +15,18 @@ no_progress = true
 # Check the specified file extensions
 extensions = ["md","txt","html", "rst"]
 
+# Website timeout in seconds
+timeout = 30
+
+# Maximum number of retries for a request before failing
+max_retries = 5
+
+# Inter-request delay in seconds to avoid rate limiting
+retry_wait_time = 10
+
+# Accept timeouts as successful (useful for CI/CD)
+accept_timeouts = true
+
 # Exclude URLs and mail addresses from checking. The values are treated as regular expressions
 exclude = [
     '^http://localhost*',


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
We've noticed that Lychee, which is used in our GitHub Actions workflows, is timing out quite frequently. In those cases, simply running "Rerun the failed jobs" manually usually resolves the issue. Nearly all of the failures seem to occur when checking URLs on the Alice & Bob website. I'll try increasing the timeout setting.

```
### Errors in README.md

* [TIMEOUT] <https://alice-bob.com/> | Timeout
```

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
