### PR TITLE
Fix Rustdoc Regressions in QuantumResource Introduced by PR #56

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ pub type Result<T> = std::result::Result<T, QrmiError>;
 /// Defines interfaces to quantum resources.
 #[async_trait]
 pub trait QuantumResource: Send + Sync {
-    async fn resource_id(&mut self) -> Result<String>;
     /// Returns resource identifier of this quantum resource.
     ///
     /// # Example
@@ -55,7 +54,7 @@ pub trait QuantumResource: Send + Sync {
     ///     Ok(())
     /// }
     /// ```
-    async fn resource_type(&mut self) -> Result<ResourceType>;
+    async fn resource_id(&mut self) -> Result<String>;
     ///
     /// Returns resource type of this quantum resource.
     ///
@@ -64,11 +63,30 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let resource_type = qrmi.resource_type().await?;
-    ///     println!("{}", resource_type.as_str()); // prints "qiskit_runtime_service"
+    ///     println!("{}", resource_type.as_str()); // prints "ibm-quantum-compute-service"
+    ///     Ok(())
+    /// }
+    /// ```
+    async fn resource_type(&mut self) -> Result<ResourceType>;
+
+    /// Returns true if device is accessible, otherwise false. A target quantum resource is not considered accessible if quantum workloads cannot be executed, even when the system itself is reachable, for example due to maintenance.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
+    ///
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
+    ///     let accessible = qrmi.is_accessible().await?;
+    ///     if !accessible {
+    ///         println!("ibm_torino is not accessible");
+    ///     }
     ///     Ok(())
     /// }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,16 +46,16 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let resource_id = qrmi.resource_id().await?;
     ///     println!("{resource_id}"); // prints "ibm_torino"
     ///     Ok(())
     /// }
     /// ```
     async fn resource_id(&mut self) -> Result<String>;
-    ///
+
     /// Returns resource type of this quantum resource.
     ///
     /// # Example
@@ -99,8 +99,8 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let token = qrmi.acquire().await?;
     ///     println!("acquisition token = {}", token);
     ///     Ok(())
@@ -115,8 +115,8 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     qrmi.release("your_acquisition_token").await?;
     ///     Ok(())
     /// }
@@ -137,9 +137,9 @@ pub trait QuantumResource: Send + Sync {
     ///     use std::fs::File;
     ///     use std::io::prelude::*;
     ///     use std::io::BufReader;
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///
     ///     let f = File::open("sampler_input.json").expect("file not found");
     ///     let mut buf_reader = BufReader::new(f);
@@ -168,9 +168,9 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     qrmi.task_stop("your_task_id").await?;
     ///     Ok(())
     /// }
@@ -188,9 +188,9 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let status = qrmi.task_status("your_task_id").await?;
     ///     println!("{:?}", status);
     ///     Ok(())
@@ -209,10 +209,10 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
     ///     let job_id = "4EAAA9E2-AD53-4C5C-8EF1-C1A3F219C427";
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let result = qrmi.task_result(&job_id).await?;
     ///     println!("{:?}", result.value);
     ///     Ok(())
@@ -231,10 +231,10 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
     ///     let job_id = "4EAAA9E2-AD53-4C5C-8EF1-C1A3F219C427";
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let log = qrmi.task_logs(&job_id).await?;
     ///     println!("{:?}", log);
     ///     Ok(())
@@ -247,9 +247,9 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let target = qrmi.target().await?;
     ///     println!("{:?}", target.value);
     ///     Ok(())
@@ -264,9 +264,9 @@ pub trait QuantumResource: Send + Sync {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     use qrmi::{ibm::IBMQiskitRuntimeService, QuantumResource};
+    ///     use qrmi::{ibm::IBMQuantumComputeService, QuantumResource};
     ///
-    ///     let mut qrmi = IBMQiskitRuntimeService::new("ibm_torino")?;
+    ///     let mut qrmi = IBMQuantumComputeService::new("ibm_torino")?;
     ///     let metadata = qrmi.metadata().await;
     ///     println!("{:?}", metadata);
     ///     Ok(())


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
PR #56 introduced regressions in the QuantumResource trait's rustdoc.

- The documentation for the trait methods resource_id() and resource_type() are shifted by one.
- The is_accessible() trait method was unexpectedly removed.

@awennersteen (@badtst , @MatthieuMoreau0 ) Could you please review ? This regression was introduced by your #56 changes. Thanks,

## Checklist ✅

- [ ] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
