### PR TITLE
Update license to Apache-2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 dynamic = ["version"]
-license = {file = "LICENSE.txt"}
+license = "Apache-2.0"
 readme = "README.md"
 description = "Quantum Resource Management Interface(QRMI)"
 description_content_type = "text/markdown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 readme = "README.md"
 description = "Quantum Resource Management Interface(QRMI)"
 description_content_type = "text/markdown"


### PR DESCRIPTION
Changed license format from file reference to string. In this way, the ambiguity on the license version is removed.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for more context.