### PR TITLE
Embed build/version info into QRMI library

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -128,13 +128,13 @@ QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
 ```
 
 The two are independent: `SPANK_QRMI_*` describes the plugin binary
-itself, `QRMI_BUILD_VERSION`/`GIT_HASH` describes the QRMI crate it was
-linked against. See the spank_qrmi plugin's own FAQ for details on the
+itself, `QRMI_BUILD_VERSION`/`QRMI_GIT_HASH` describes the QRMI crate it was
+linked against. See the spank_qrmi plugin's own [FAQ](https://github.com/qiskit-community/spank-plugins/blob/main/docs/FAQ.md) for details on the
 former.
 
 #### Notes
 
-- If `GIT_HASH` shows `unknown`, QRMI was most likely built from a source
+- If `QRMI_GIT_HASH` shows `unknown`, QRMI was most likely built from a source
   tree without a `.git` directory (e.g. an extracted release tarball, or a
   local checkout pointed at via `QRMI_ROOT` in the consuming project's
   build).

--- a/FAQ.md
+++ b/FAQ.md
@@ -87,14 +87,14 @@ any binary that links it), so you can check it without running the code.
 #### Using `strings`
 
 ```shell-session
-$ strings /path/to/spank_qrmi.so | grep QRMI_BUILD_VERSION
+$ strings /path/to/libqrmi.so | grep QRMI_BUILD_VERSION
 QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
 ```
 
 #### Using `readelf`
 
 ```shell-session
-$ readelf -p .version_info /path/to/spank_qrmi.so
+$ readelf -p .version_info /path/to/libqrmi.so
 
 String dump of section '.version_info':
   [    4f]  QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013

--- a/FAQ.md
+++ b/FAQ.md
@@ -5,6 +5,8 @@
 1. [General Question](#general-questions)
 2. [Job Execution Errors](#job-execution-errors)
     1. [I get an error `error: spank_qrmi_c, failed to acquire resource: ibm_brisbane`](#i-get-an-error-error-spank_qrmi_c-failed-to-acquire-resource-ibm_brisbane)
+3. [Release and Deployment](#release-and-deployment)
+    1. [How can I check which version of QRMI is linked into a binary?](#how-can-i-check-which-version-of-qrmi-is-linked-into-a-binary)
 
 ## Job Execution Errors
 
@@ -73,3 +75,78 @@ You are not authorized to run a session when using the open plan.
       }
    }
 ```
+
+## Release and deployment
+
+### How can I check which version of QRMI is linked into a binary?
+
+Every build of QRMI embeds its own crate version and git commit hash
+directly into the compiled artifact (shared library, static library, or
+any binary that links it), so you can check it without running the code.
+
+#### Using `strings`
+
+```shell-session
+$ strings /path/to/spank_qrmi.so | grep QRMI_BUILD_VERSION
+QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
+```
+
+#### Using `readelf`
+
+```shell-session
+$ readelf -p .version_info /path/to/spank_qrmi.so
+
+String dump of section '.version_info':
+  [    4f]  QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
+```
+
+(The exact offset shown after `[ ]` will vary depending on what else is
+linked into the same `.version_info` section — see below.)
+
+#### What each field means
+
+| Field | Meaning |
+|---|---|
+| `QRMI_BUILD_VERSION` | QRMI's crate version, from `CARGO_PKG_VERSION` (i.e. the `version` field in `Cargo.toml`) at the time it was built. |
+| `QRMI_GIT_HASH` | The exact git commit QRMI was built from, resolved via `git rev-parse --short=12 HEAD` in `build.rs`. Useful when the consuming project pins a moving branch (e.g. `main`) rather than a fixed release tag. |
+
+This is especially useful when diagnosing issues caused by a version
+mismatch between a deployed binary that links QRMI (such as the
+[spank_qrmi](#) Slurm plugin) and the QRMI Python package used by client
+workloads — you can confirm exactly which QRMI build is present without
+rebuilding or adding logging.
+
+#### If you're looking at `spank_qrmi.so` specifically
+
+`spank_qrmi.so` embeds its own version/git-hash marker alongside QRMI's, in
+the same `.version_info` section:
+
+```shell-session
+$ strings spank_qrmi.so | grep -E "SPANK_QRMI|QRMI_BUILD"
+SPANK_QRMI_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=0dac1793b013
+QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
+```
+
+The two are independent: `SPANK_QRMI_*` describes the plugin binary
+itself, `QRMI_BUILD_VERSION`/`GIT_HASH` describes the QRMI crate it was
+linked against. See the spank_qrmi plugin's own FAQ for details on the
+former.
+
+#### Notes
+
+- If `GIT_HASH` shows `unknown`, QRMI was most likely built from a source
+  tree without a `.git` directory (e.g. an extracted release tarball, or a
+  local checkout pointed at via `QRMI_ROOT` in the consuming project's
+  build).
+- If neither `strings` nor `readelf` show a `.version_info` section (or it
+  only shows a `SPANK_QRMI_*` entry with no `QRMI_BUILD_VERSION`), the
+  binary may have been built before this feature was introduced, or the
+  section may have been removed by a full `strip -s` pass in the
+  deployment pipeline. Re-run `strip --strip-debug` instead, or add
+  `--keep-section=.version_info` to the `strip`/`objcopy` invocation, to
+  preserve it.
+- This works the same way regardless of whether QRMI was linked as a
+  shared library (`cdylib`) or a static library (`staticlib`) — the marker
+  survives static linking as long as at least one other QRMI symbol is
+  referenced by the final binary.
+

--- a/FAQ.md
+++ b/FAQ.md
@@ -125,6 +125,11 @@ the same `.version_info` section:
 $ strings spank_qrmi.so | grep -E "SPANK_QRMI|QRMI_BUILD"
 SPANK_QRMI_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=0dac1793b013
 QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
+
+$ readelf -p .version_info spank_qrmi.so
+String dump of section '.version_info':
+  [     0]  SPANK_QRMI_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=3845dd911381
+  [    3b]  QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:7a9573703ac4
 ```
 
 The two are independent: `SPANK_QRMI_*` describes the plugin binary

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2025
+// (C) Copyright IBM 2025-2026
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -9,6 +9,8 @@
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
+
+use std::process::Command;
 
 // For C API bindings
 fn main() {
@@ -32,4 +34,14 @@ fn main() {
 
     println!("cargo:rerun-if-changed=/src/*");
     println!("cargo:rerun-if-changed=/build.rs");
+
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Exposes GIT_HASH to env!("GIT_HASH") in lib.rs, at compile time.
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash.trim());
 }

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -64,3 +64,14 @@ rename_variants = "ScreamingSnakeCase"
 "ResourceDef" = "QrmiResourceDef"
 "Payload" = "QrmiPayload"
 "ReturnCode" = "QrmiReturnCode"
+
+[export]
+# VERSION_INFO is a build-time marker embedded into the `.version_info` ELF
+# section for offline inspection via `strings`/`readelf` (see lib.rs). It is
+# not a real part of the public C API and isn't meant to be called or read
+# from C code, so we exclude it from the generated header. Without this,
+# cbindgen emits `extern const uint8_t VERSION_INFO[VERSION_LEN];`, but
+# VERSION_LEN is a private (non-`pub`) const that cbindgen silently skips,
+# leaving VERSION_LEN undeclared in the generated qrmi.h and breaking the C
+# build with "'VERSION_LEN' undeclared here".
+exclude = ["VERSION_INFO"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,57 @@ pub mod models;
 #[cfg(feature = "pyo3")]
 pub mod pyext;
 
+// Everything below runs entirely INSIDE THE COMPILER (rustc), while it
+// is compiling this crate. None of it produces runtime instructions in
+// the final binary — only the final, already-computed byte array is
+// emitted into the `.version_info` ELF section. When spank_qrmi loads
+// this library and runs, none of this code executes again; there is
+// nothing left to execute, only static data sitting in the binary.
+
+// `env!` and `concat!` are macros: they are expanded by the compiler's
+// macro expansion pass, long before any type-checking or codegen. This
+// is NOT the same as calling `std::env::var(...)` at runtime — the
+// value of GIT_HASH (set by build.rs above) is baked into the source
+// text itself as if you had typed the literal string by hand.
+const VERSION_STR: &str = concat!(
+    "QRMI_BUILD_VERSION:", env!("CARGO_PKG_VERSION"),
+    ";QRMI_GIT_HASH:", env!("GIT_HASH"),
+);
+
+// A `const` is evaluated by the compiler's constant evaluator (CTFE —
+// Compile-Time Function Evaluation) at compile time. `.len()` on a
+// `&'static str` is computed here, not when the plugin runs.
+const VERSION_LEN: usize = VERSION_STR.len() + 1;
+
+// A `const fn` can be called from a `const` context, in which case the
+// compiler runs its body through CTFE — effectively a small interpreter
+// built into rustc — during compilation, not at runtime. The `while`
+// loop below never becomes a real loop in the compiled machine code;
+// rustc executes it once, internally, while compiling, and only the
+// resulting array of bytes is kept.
+const fn str_to_array<const N: usize>(s: &str) -> [u8; N] {
+    let bytes = s.as_bytes();
+    let mut arr = [0u8; N];
+    let mut i = 0;
+    while i < bytes.len() {
+        arr[i] = bytes[i];
+        i += 1;
+    }
+    arr
+}
+
+// By the time we reach this line, `str_to_array(VERSION_STR)` has
+// ALREADY been fully evaluated by the compiler; VERSION_INFO's contents
+// are a fixed, known byte sequence baked directly into the binary's
+// `.version_info` section (see #[link_section] below). `#[used]` and
+// `#[no_mangle]` are linker/codegen directives, not runtime behavior:
+// they only affect whether/how the linker keeps and names this data —
+// they do not cause any code to run when the plugin is loaded.
+#[no_mangle]
+#[used]
+#[link_section = ".version_info"]
+pub static VERSION_INFO: [u8; VERSION_LEN] = str_to_array(VERSION_STR);
+
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use async_trait::async_trait;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,10 @@ pub mod pyext;
 // value of GIT_HASH (set by build.rs above) is baked into the source
 // text itself as if you had typed the literal string by hand.
 const VERSION_STR: &str = concat!(
-    "QRMI_BUILD_VERSION:", env!("CARGO_PKG_VERSION"),
-    ";QRMI_GIT_HASH:", env!("GIT_HASH"),
+    "QRMI_BUILD_VERSION:",
+    env!("CARGO_PKG_VERSION"),
+    ";QRMI_GIT_HASH:",
+    env!("GIT_HASH"),
 );
 
 // A `const` is evaluated by the compiler's constant evaluator (CTFE —


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
### Review & Approve

Urgency: Not urgent. That said, a quick review would give us a chance to get this into the current customer upgrade window, so faster turnaround is appreciated if feasible.

Target date: Hoping to complete until early next week.


### Background

This is a companion change to [spank-plugins PR #202](https://github.com/qiskit-community/spank-plugins/pull/202) .
While investigating a quantum-workload issue during a customer cluster upgrade, we found it was hard to tell which QRMI build was actually linked into the deployed `spank_qrmi.so` without rebuilding or tracing through job
logs. The spank-plugins PR embeds spank_qrmi's own version into a `.version_info` ELF section; this PR does the equivalent for QRMI itself, so both pieces of the puzzle are visible from the same deployed binary with a single `strings`/`readelf` command.

### Summary

Embeds QRMI's crate version (`CARGO_PKG_VERSION`) and the exact git commit it was built from into a dedicated `.version_info` ELF section, so it can be inspected offline without running any code:

```bash
$ strings libqrmi.so | grep QRMI_BUILD_VERSION
QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013

$ readelf -p .version_info libqrmi.so
String dump of section '.version_info':
  [    4f]  QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
```

This coexists cleanly with spank_qrmi's own marker in the same section once linked together (distinct symbol names, no collision):

```bash
$ strings spank_qrmi.so | grep -E "SPANK_QRMI|QRMI_BUILD"
SPANK_QRMI_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=0dac1793b013
QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013

$ readelf -p .version_info spank_qrmi.so
String dump of section '.version_info':
  [     0]  SPANK_QRMI_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=3845dd911381
  [    3b]  QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:7a9573703ac4
```

### Changes

- **`build.rs`**: resolves the exact git commit QRMI was built from via `git rev-parse --short=12 HEAD` and exposes it to the crate at compile time as `GIT_HASH` via `cargo:rustc-env=`. Falls back to `"unknown"` when
  built outside a git checkout (e.g. `-DQRMI_ROOT=` pointing at an extracted tarball with no `.git` directory).
- **`lib.rs`**: adds a `VERSION_INFO` byte array built from `env!("CARGO_PKG_VERSION")` and `env!("GIT_HASH")`, placed into a `.version_info` ELF section via `#[link_section]`. A few details worth
  calling out explicitly in review, since they were each needed to make this actually show up in the final linked binary:
  - The string is assembled at **compile time** via `concat!`/`env!`/a `const fn` (compile-time function evaluation), not at runtime — there is no runtime cost and nothing "executes" when the plugin loads.
  - Uses a fixed-size `[u8; N]` array rather than `&[u8]`/`&str`: a slice reference is a fat pointer (pointer + length) and would put a relocatable pointer into `.version_info` instead of the actual text.
  - Requires **both** `#[used]` (survive Rust/LLVM dead-code elimination) **and** `#[no_mangle]` (export the symbol so it survives the linker's `--gc-sections`, and so the containing object file isn't dropped when QRMI is linked in as a static archive and only some of its other symbols are referenced).
- **`cbindgen.toml`**: adds `VERSION_INFO` to `[export] exclude`. Without this, cbindgen emits `extern const uint8_t VERSION_INFO[VERSION_LEN];` into the generated `qrmi.h`, but `VERSION_LEN` is a private (non-`pub`)
  const that cbindgen silently skips — leaving `VERSION_LEN` undeclared in the header and breaking the C build
  (`'VERSION_LEN' undeclared here`). `VERSION_INFO` is purely an offline-inspection marker, not part of the public C API, so it has no business being in the generated header at all.
  
### Testing

- Verified `readelf -p .version_info` / `strings` show the expected string on a locally built `cdylib` and after linking a `staticlib` build into a separate final binary (mirroring how spank_qrmi links against `libqrmi.a`), including with only an unrelated QRMI function referenced from the C side (confirms the object file isn't dropped during archive member pruning).
- Verified `cbindgen.toml` change: regenerated `qrmi.h` and confirmed no `VERSION_INFO`/`VERSION_LEN` declarations appear, and that `spank_qrmi.c` (from the companion PR) compiles cleanly against it.
- Confirmed `git rev-parse --short=12 HEAD` in `build.rs` matches the same 12-character abbreviation used on the spank_qrmi side, so the two hashes are directly comparable when both are visible in the same binary.
- full build via the actual `ExternalProject`/CMake fetch path used by spank-plugins (both default GitHub fetch and
  `-DQRMI_ROOT=` local-checkout path).

### Notes / follow-ups

- Not a behavior change to QRMI's actual functionality — purely additive metadata.

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?
   - Please ignore lychee error because spank plugin PR is still under review.

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
