### PR TITLE
Restrict .version_info embedding to Linux to fix macOS build failure

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -80,6 +80,9 @@ You are not authorized to run a session when using the open plan.
 
 ### How can I check which version of QRMI is linked into a binary?
 
+> [!NOTE]
+> Linux only.
+
 Every build of QRMI embeds its own crate version and git commit hash
 directly into the compiled artifact (shared library, static library, or
 any binary that links it), so you can check it without running the code.

--- a/FAQ.md
+++ b/FAQ.md
@@ -122,13 +122,13 @@ rebuilding or adding logging.
 the same `.version_info` section:
 
 ```shell-session
-$ strings spank_qrmi.so | grep -E "SPANK_QRMI|QRMI_BUILD"
-SPANK_QRMI_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=0dac1793b013
+$ strings /path/to/spank_qrmi.so | grep -E "SPANK_QRMI|QRMI_BUILD"
+SPANK_QRMI_BUILD_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=0dac1793b013
 QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:0dac1793b013
 
-$ readelf -p .version_info spank_qrmi.so
+$ readelf -p .version_info /path/to/spank_qrmi.so
 String dump of section '.version_info':
-  [     0]  SPANK_QRMI_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=3845dd911381
+  [     0]  SPANK_QRMI_BUILD_VERSION=0.11.0;SPANK_QRMI_GIT_HASH=3845dd911381
   [    3b]  QRMI_BUILD_VERSION:0.24.0;QRMI_GIT_HASH:7a9573703ac4
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,58 +30,59 @@ pub mod models;
 #[cfg(feature = "pyo3")]
 pub mod pyext;
 
-// Everything below runs entirely INSIDE THE COMPILER (rustc), while it
-// is compiling this crate. None of it produces runtime instructions in
-// the final binary — only the final, already-computed byte array is
-// emitted into the `.version_info` ELF section. When spank_qrmi loads
-// this library and runs, none of this code executes again; there is
-// nothing left to execute, only static data sitting in the binary.
+// Embeds QRMI's version/git-hash into a `.version_info` ELF section for
+// offline inspection via `strings`/`readelf`. Linux (ELF) only: macOS
+// (Mach-O) and Windows (PE/COFF) use different, incompatible section-name
+// syntaxes, and this marker isn't needed on those platforms, so the whole
+// thing is compiled out there instead of trying to support every format.
+#[cfg(target_os = "linux")]
+mod version_info {
+    // `env!` and `concat!` are macros: they are expanded by the compiler's
+    // macro expansion pass, long before any type-checking or codegen. This
+    // is NOT the same as calling `std::env::var(...)` at runtime — the
+    // value of GIT_HASH (set by build.rs above) is baked into the source
+    // text itself as if you had typed the literal string by hand.
+    const VERSION_STR: &str = concat!(
+        "QRMI_BUILD_VERSION:",
+        env!("CARGO_PKG_VERSION"),
+        ";QRMI_GIT_HASH:",
+        env!("GIT_HASH"),
+    );
 
-// `env!` and `concat!` are macros: they are expanded by the compiler's
-// macro expansion pass, long before any type-checking or codegen. This
-// is NOT the same as calling `std::env::var(...)` at runtime — the
-// value of GIT_HASH (set by build.rs above) is baked into the source
-// text itself as if you had typed the literal string by hand.
-const VERSION_STR: &str = concat!(
-    "QRMI_BUILD_VERSION:",
-    env!("CARGO_PKG_VERSION"),
-    ";QRMI_GIT_HASH:",
-    env!("GIT_HASH"),
-);
+    // A `const` is evaluated by the compiler's constant evaluator (CTFE —
+    // Compile-Time Function Evaluation) at compile time. `.len()` on a
+    // `&'static str` is computed here, not when the plugin runs.
+    const VERSION_LEN: usize = VERSION_STR.len() + 1;
 
-// A `const` is evaluated by the compiler's constant evaluator (CTFE —
-// Compile-Time Function Evaluation) at compile time. `.len()` on a
-// `&'static str` is computed here, not when the plugin runs.
-const VERSION_LEN: usize = VERSION_STR.len() + 1;
-
-// A `const fn` can be called from a `const` context, in which case the
-// compiler runs its body through CTFE — effectively a small interpreter
-// built into rustc — during compilation, not at runtime. The `while`
-// loop below never becomes a real loop in the compiled machine code;
-// rustc executes it once, internally, while compiling, and only the
-// resulting array of bytes is kept.
-const fn str_to_array<const N: usize>(s: &str) -> [u8; N] {
-    let bytes = s.as_bytes();
-    let mut arr = [0u8; N];
-    let mut i = 0;
-    while i < bytes.len() {
-        arr[i] = bytes[i];
-        i += 1;
+    // A `const fn` can be called from a `const` context, in which case the
+    // compiler runs its body through CTFE — effectively a small interpreter
+    // built into rustc — during compilation, not at runtime. The `while`
+    // loop below never becomes a real loop in the compiled machine code;
+    // rustc executes it once, internally, while compiling, and only the
+    // resulting array of bytes is kept.
+    const fn str_to_array<const N: usize>(s: &str) -> [u8; N] {
+        let bytes = s.as_bytes();
+        let mut arr = [0u8; N];
+        let mut i = 0;
+        while i < bytes.len() {
+            arr[i] = bytes[i];
+            i += 1;
+        }
+        arr
     }
-    arr
-}
 
-// By the time we reach this line, `str_to_array(VERSION_STR)` has
-// ALREADY been fully evaluated by the compiler; VERSION_INFO's contents
-// are a fixed, known byte sequence baked directly into the binary's
-// `.version_info` section (see #[link_section] below). `#[used]` and
-// `#[no_mangle]` are linker/codegen directives, not runtime behavior:
-// they only affect whether/how the linker keeps and names this data —
-// they do not cause any code to run when the plugin is loaded.
-#[no_mangle]
-#[used]
-#[link_section = ".version_info"]
-pub static VERSION_INFO: [u8; VERSION_LEN] = str_to_array(VERSION_STR);
+    // By the time we reach this line, `str_to_array(VERSION_STR)` has
+    // ALREADY been fully evaluated by the compiler; VERSION_INFO's contents
+    // are a fixed, known byte sequence baked directly into the binary's
+    // `.version_info` section (see #[link_section] below). `#[used]` and
+    // `#[no_mangle]` are linker/codegen directives, not runtime behavior:
+    // they only affect whether/how the linker keeps and names this data —
+    // they do not cause any code to run when the plugin is loaded.
+    #[no_mangle]
+    #[used]
+    #[link_section = ".version_info"]
+    pub static VERSION_INFO: [u8; VERSION_LEN] = str_to_array(VERSION_STR);
+}
 
 use crate::models::{Payload, ResourceType, Target, TaskResult, TaskStatus};
 use async_trait::async_trait;


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->

## Review & Approve

**Urgency:** Not urgent, but this is currently blocking local builds on macOS, so a relatively quick look would help unblock anyone developing on a Mac.

**Target date:** within a week

### Summary

Building on macOS currently fails:

```
rustc-LLVM ERROR: Global variable 'VERSION_INFO' has an invalid section specifier '.version_info': mach-o section specifier requires a segment and section separated by a comma.
```

`.version_info` (no comma) is ELF-specific section-naming syntax. Mach-O (macOS) requires `"SEGMENT,section"` syntax instead (e.g. `"__TEXT,__version_info"`), and PE/COFF (Windows) has yet another set of constraints (8-character section name limit, no segment/section split).

Since this marker only matters for the actual Slurm/Linux deployment target, this PR wraps the whole `version_info` module (the string constant, the `const fn`, and the exported static) in `#[cfg(target_os = "linux")]` instead of trying to support every object format. On macOS/Windows the module is compiled out entirely, so local development on a Mac is no longer blocked by this.

### Changes

- **`lib.rs`**: wrapped the existing `VERSION_INFO` / `VERSION_STR` / `VERSION_LEN` / `str_to_array` items in a private
  `#[cfg(target_os = "linux")] mod version_info { ... }`. No change to the Linux behavior or the embedded string format.
- Also fixed some metadata names in FAQ.md.

### Testing

- Verified the Linux build still produces the expected `.version_info`  section (`readelf -p .version_info` / `strings` unchanged).
- Verified the MacOS build

### Notes / follow-ups

- Windows isn't handled either, for the same reason (incompatible section syntax) — not addressed here since it isn't currently blocking anyone, but the same `#[cfg(target_os = "...")]` pattern would extend cleanly if needed later.
- Not a behavior change on Linux — purely a build-fix for other platforms.

## Checklist ✅

- [ ] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [ ] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
