### PR TITLE
[IBM] Fix typo in backend.py

### DIFF
--- a/python/qrmi/primitives/ibm/backend.py
+++ b/python/qrmi/primitives/ibm/backend.py
@@ -147,7 +147,7 @@ class QRMIBackend(BackendV2):
             )
             self._target = convert_to_target(
                 configuration=self._configuration,  # type: ignore[arg-type]
-                prperties=self._properties,
+                properties=self._properties,
             )
 
     @property


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
### Review & Approve
Urgency: Not urgent, but this is currently blocking the work by IBM internal user, so a relatively quick look would help unblock anyone with using `get_backend()`.

Target date: Within one week.

### Summary

Current implementation does not set backend properties to `convert_to_target()` due to typo. This PR fixes 1 typo in `backend.py`. 

### Changes:
- Renamed a argument name from `prperties` to `properties`.

### Testing:
- Confirmed created Target object can be used to generate ISA circuit correctly. 

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
