### PR TITLE
Add asyncio-native  Python binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,6 +2484,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-async-runtimes"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
 name = "pyo3-build-config"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,6 +2602,7 @@ dependencies = [
  "pasqal-cloud-api",
  "pasqal-local-api",
  "pyo3",
+ "pyo3-async-runtimes",
  "pyo3-stub-gen",
  "quantum-system-api",
  "quantum_compute_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ required-features = ["build-binary"]
 [features]
 default = ["quantum-system-api/iqp_retry_policy"]
 pyo3 = ["dep:pyo3", "dep:pyo3-stub-gen"]
+# asyncio-native `AsyncQuantumResource` bindings (src/pyext_async.rs).
+# Separate from `pyo3` so existing consumers aren't forced to pull in
+# pyo3-async-runtimes + a global tokio runtime just to build the sync API.
+pyo3-async = ["pyo3", "dep:pyo3-async-runtimes"]
 build-binary = ["dep:signal-hook-tokio", "dep:signal-hook", "dep:eyre"]
 munge = ["pasqal-local-api/munge"]
 
@@ -48,6 +52,7 @@ anyhow = { version = "1.0.97", features = ["backtrace"] }
 thiserror = "2.0"
 glob = "0.3"
 pyo3 = { version = "0.29.0", features = ["anyhow"], optional = true }
+pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"], optional = true }
 ffi_helpers = "0.3.0"
 async-trait = "0.1.88"
 dotenv = "0.15.0"

--- a/examples/qrmi/python/async/async_example.py
+++ b/examples/qrmi/python/async/async_example.py
@@ -1,0 +1,71 @@
+#
+# (C) Copyright 2026 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""An example of IBM Quantum System QRMI python-bindings (asyncio version)"""
+
+import asyncio
+import json
+import argparse
+from dotenv import load_dotenv
+from qrmi import AsyncQuantumResource, ResourceType, Payload, TaskStatus
+
+
+async def main(args: argparse.Namespace) -> None:
+    """main"""
+    qrmi = AsyncQuantumResource(args.backend, ResourceType.IBMQuantumSystem)
+    print(qrmi)
+    print(
+        f"Selected resource: id={await qrmi.resource_id()} "
+        f"type={str(await qrmi.resource_type())}"
+    )
+
+    print(await qrmi.is_accessible())
+
+    lock = await qrmi.acquire()
+    print(f"lock {lock}")
+
+    target_json = json.loads((await qrmi.target()).value)
+    print(json.dumps(target_json, indent=2))
+    print(await qrmi.metadata())
+
+    with open(args.input, encoding="utf-8") as f:
+        primitive_input = f.read()
+        payload = Payload.QiskitPrimitive(input=primitive_input, program_id=args.program_id)
+        job_id = await qrmi.task_start(payload)
+        print(f"Task started {job_id}")
+
+        while True:
+            status = await qrmi.task_status(job_id)
+            if status not in [TaskStatus.Running, TaskStatus.Queued]:
+                break
+
+            await asyncio.sleep(1)
+
+        print(f"Task ended - {await qrmi.task_status(job_id)}")
+        print((await qrmi.task_result(job_id)).value)
+
+        print(await qrmi.task_logs(job_id))
+
+        await qrmi.task_stop(job_id)
+
+    await qrmi.release(lock)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="An example of IBM Quantum System QRMI")
+    parser.add_argument("backend", help="backend name")
+    parser.add_argument("input", help="primitive input file")
+    parser.add_argument("program_id", help="'estimator' or 'sampler'")
+    parsed_args = parser.parse_args()
+
+    load_dotenv()
+
+    asyncio.run(main(parsed_args))

--- a/examples/qrmi/python/async/is_accessible_concurrent.py
+++ b/examples/qrmi/python/async/is_accessible_concurrent.py
@@ -1,0 +1,49 @@
+#
+# (C) Copyright 2026 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Check accessibility of multiple IBM Quantum System backends concurrently."""
+
+import asyncio
+import argparse
+from dotenv import load_dotenv
+from qrmi import AsyncQuantumResource, ResourceType
+
+
+async def check_one(backend: str) -> tuple[str, bool]:
+    """Check accessibility of one backend"""
+    qrmi = AsyncQuantumResource(backend, ResourceType.IBMQuantumSystem)
+    accessible = await qrmi.is_accessible()
+    return backend, accessible
+
+
+async def main(backends: list[str]) -> None:
+    """main"""
+
+    # Each `check_one(...)` call creates its own AsyncQuantumResource, so
+    # the awaits below run concurrently on QRMI's shared tokio runtime —
+    # this takes roughly as long as the single slowest backend check, not
+    # the sum of all of them.
+    results = await asyncio.gather(*(check_one(b) for b in backends))
+
+    for backend, accessible in results:
+        print(f"{backend}: is_accessible={accessible}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check accessibility of multiple backends concurrently"
+    )
+    parser.add_argument("backends", nargs="+", help="one or more backend names")
+    parsed_args = parser.parse_args()
+
+    load_dotenv()
+
+    asyncio.run(main(parsed_args.backends))

--- a/examples/qrmi/python/async/task_run_concurrent.py
+++ b/examples/qrmi/python/async/task_run_concurrent.py
@@ -1,0 +1,124 @@
+#
+# (C) Copyright 2026 IBM. All Rights Reserved.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Submit a primitive input to multiple IBM Quantum System backends
+concurrently, one input file and one program id (estimator/sampler) per
+backend, and collect all results once every job has finished.
+"""
+
+import asyncio
+import argparse
+from dotenv import load_dotenv
+from qrmi import AsyncQuantumResource, ResourceType, Payload, TaskStatus
+
+
+async def run_on_backend(backend: str, primitive_input: str, program_id: str) -> str:
+    """Acquire `backend`, run one task on it, and return the result JSON.
+
+    This whole function is one coroutine, so multiple calls to it (one per
+    backend) can be scheduled together with `asyncio.gather`. The `await`s
+    inside it (task_start / task_status / task_result / ...) yield control
+    back to the event loop, letting the *other* backends' coroutines make
+    progress while this one is, say, waiting on a queued job.
+    """
+    qrmi = AsyncQuantumResource(backend, ResourceType.IBMQuantumSystem)
+
+    lock = await qrmi.acquire()
+    try:
+        payload = Payload.QiskitPrimitive(input=primitive_input, program_id=program_id)
+        job_id = await qrmi.task_start(payload)
+        print(f"[{backend}] task started: {job_id}")
+
+        while True:
+            status = await qrmi.task_status(job_id)
+            if status not in [TaskStatus.Running, TaskStatus.Queued]:
+                break
+            await asyncio.sleep(1)
+
+        print(f"[{backend}] task ended: {status}")
+        result = await qrmi.task_result(job_id)
+        await qrmi.task_stop(job_id)
+        return result.value
+    finally:
+        # Runs even if task_start/task_status/task_result raised, so a
+        # failure on one backend doesn't leave its lock held forever.
+        await qrmi.release(lock)
+
+
+async def main(backends: list[str], input_paths: list[str], program_ids: list[str]) -> None:
+    """main"""
+    primitive_inputs = []
+    for path in input_paths:
+        with open(path, encoding="utf-8") as f:
+            primitive_inputs.append(f.read())
+
+    # `return_exceptions=True` so one backend's failure doesn't cancel the
+    # others' in-flight work; each entry in `results` is either the result
+    # JSON string or the exception that was raised for that backend.
+    results = await asyncio.gather(
+        *(
+            run_on_backend(b, primitive_input, program_id)
+            for b, primitive_input, program_id in zip(backends, primitive_inputs, program_ids)
+        ),
+        return_exceptions=True,
+    )
+
+    for backend, result in zip(backends, results):
+        if isinstance(result, Exception):
+            print(f"[{backend}] FAILED: {result!r}")
+        else:
+            print(f"[{backend}] result: {result}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run a primitive on multiple backends concurrently"
+    )
+    parser.add_argument(
+        "--backend",
+        action="append",
+        required=True,
+        dest="backends",
+        metavar="BACKEND",
+        help="backend name; repeat once per backend, paired by order with --input/--program-id",
+    )
+    parser.add_argument(
+        "--input",
+        action="append",
+        required=True,
+        dest="inputs",
+        metavar="FILE",
+        help="primitive input file; repeat once per backend, paired by order with --backend/--program-id",
+    )
+    parser.add_argument(
+        "--program-id",
+        action="append",
+        required=True,
+        dest="program_ids",
+        metavar="'estimator'|'sampler'",
+        help="program id; repeat once per backend, paired by order with --backend/--input",
+    )
+    parsed_args = parser.parse_args()
+
+    counts = {
+        "--backend": len(parsed_args.backends),
+        "--input": len(parsed_args.inputs),
+        "--program-id": len(parsed_args.program_ids),
+    }
+    if len(set(counts.values())) != 1:
+        parser.error(
+            "each --backend needs exactly one matching --input and --program-id, "
+            f"in order, but got: {counts}"
+        )
+
+    load_dotenv()
+
+    asyncio.run(main(parsed_args.backends, parsed_args.inputs, parsed_args.program_ids))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ repository = "https://github.com/qiskit-community/qrmi"
 [tool.maturin]
 python-source = "python"
 module-name   = "qrmi._core" 
-features = ["pyo3/abi3", "qrmi/pyo3"]
+features = ["pyo3/abi3", "qrmi/pyo3", "qrmi/pyo3-async"]
 python-packages = [
     "qrmi",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ mod cext;
 pub mod models;
 #[cfg(feature = "pyo3")]
 pub mod pyext;
+#[cfg(feature = "pyo3-async")]
+pub mod pyext_async;
 
 // Embeds QRMI's version/git-hash into a `.version_info` ELF section for
 // offline inspection via `strings`/`readelf`. Linux (ELF) only: macOS

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -28,12 +28,12 @@ use tokio::runtime::Runtime;
 // `pyext::ResourceType`, `pyext::EnvVarNotSetError`, etc. keep working
 // unchanged.
 pub(crate) mod common;
+use common::to_py_err;
 pub use common::{
     AuthenticationFailedError, ConfigError, EnvVarNotSetError, InvalidInputError, QrmiError_,
     ResourceNotFoundError, ResourceType, TaskNotFoundError, TaskNotReadyError,
     UnsupportedPayloadError, UnsupportedResourceTypeError,
 };
-use common::to_py_err;
 
 #[gen_stub_pyclass]
 #[pyclass]

--- a/src/pyext.rs
+++ b/src/pyext.rs
@@ -11,135 +11,29 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::error::{QrmiError, QrmiErrorKind};
+use crate::error::QrmiError;
 use crate::ibm::IBMQiskitRuntimeServiceProvider;
 use crate::ibm::IBMQuantumComputeServiceProvider;
 use crate::ibm::IBMQuantumSystemProvider;
 use crate::models::{Payload, ResourceDef, Target, TaskResult, TaskStatus};
 use crate::QuantumResource;
 use pyo3::prelude::*;
-use pyo3_stub_gen::{create_exception, define_stub_info_gatherer, derive::*};
+use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 use tokio::runtime::Runtime;
 
-create_exception!(
-    qrmi._core,
-    QrmiError_,
-    pyo3::exceptions::PyRuntimeError,
-    "Base class for all QRMI-specific errors. Catching this catches any \
-     error QRMI itself raises (as opposed to errors surfaced verbatim from \
-     an underlying vendor library)."
-);
-create_exception!(
-    qrmi._core,
-    EnvVarNotSetError,
-    QrmiError_,
-    "A required environment variable was not set."
-);
-create_exception!(
-    qrmi._core,
-    ConfigError,
-    QrmiError_,
-    "A configuration value was missing, could not be parsed, or was \
-     otherwise invalid (covers `QrmiError::ParseError`, \
-     `QrmiError::MissingConfigKey`, and `QrmiError::InvalidConfig`)."
-);
-create_exception!(
-    qrmi._core,
-    UnsupportedResourceTypeError,
-    QrmiError_,
-    "Dynamic discovery was requested for an unsupported resource type."
-);
-create_exception!(
-    qrmi._core,
-    UnsupportedPayloadError,
-    QrmiError_,
-    "The payload (or a value within it, such as a program ID) is not \
-     supported by this backend."
-);
-create_exception!(
-    qrmi._core,
-    TaskNotReadyError,
-    QrmiError_,
-    "The task is not in a state that allows the requested operation \
-     (e.g. its result was requested while it is still running)."
-);
-create_exception!(
-    qrmi._core,
-    InvalidInputError,
-    QrmiError_,
-    "A value QRMI was given was invalid, whether QRMI itself rejected it \\
-     locally (e.g. a malformed `filters` string, JSON, or UTF-8) or a \\
-     vendor's API rejected the resulting request after receiving it."
-);
-create_exception!(
-    qrmi._core,
-    ResourceNotFoundError,
-    QrmiError_,
-    "The named resource (e.g. a backend) does not exist."
-);
-create_exception!(
-    qrmi._core,
-    TaskNotFoundError,
-    QrmiError_,
-    "The named task (e.g. a job) does not exist, or has already been removed."
-);
-create_exception!(
-    qrmi._core,
-    AuthenticationFailedError,
-    QrmiError_,
-    "The request's credentials were missing or rejected by the vendor's API."
-);
-
-/// Converts a [`QrmiError`] into the [`PyErr`] subclass matching its kind,
-/// so Python code can `except qrmi.TaskNotReadyError` instead of parsing
-/// `RuntimeError` message text. See `QrmiError::kind` for the mapping.
-fn to_py_err(err: QrmiError) -> PyErr {
-    let msg = err.to_string();
-    match err.kind() {
-        QrmiErrorKind::EnvVarNotSet => EnvVarNotSetError::new_err(msg),
-        QrmiErrorKind::ParseError
-        | QrmiErrorKind::MissingConfigKey
-        | QrmiErrorKind::InvalidConfig => ConfigError::new_err(msg),
-        QrmiErrorKind::UnsupportedResourceType => UnsupportedResourceTypeError::new_err(msg),
-        QrmiErrorKind::UnsupportedPayload => UnsupportedPayloadError::new_err(msg),
-        QrmiErrorKind::TaskNotReady => TaskNotReadyError::new_err(msg),
-        QrmiErrorKind::InvalidInput => InvalidInputError::new_err(msg),
-        QrmiErrorKind::ResourceNotFound => ResourceNotFoundError::new_err(msg),
-        QrmiErrorKind::TaskNotFound => TaskNotFoundError::new_err(msg),
-        QrmiErrorKind::AuthenticationFailed => AuthenticationFailedError::new_err(msg),
-        QrmiErrorKind::Other => QrmiError_::new_err(msg),
-    }
-}
-
-#[pyclass(eq, eq_int, hash, frozen, from_py_object)]
-#[gen_stub_pyclass_enum]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ResourceType {
-    IBMQuantumSystem,
-    IBMQiskitRuntimeService,
-    IBMQuantumComputeService,
-    PasqalCloud,
-    PasqalLocal,
-    AliceBobFelis,
-    IQMServer,
-}
-impl From<ResourceType> for crate::models::ResourceType {
-    fn from(value: ResourceType) -> Self {
-        match value {
-            ResourceType::IBMQuantumSystem => crate::models::ResourceType::IBMQuantumSystem,
-            ResourceType::IBMQiskitRuntimeService => {
-                crate::models::ResourceType::QiskitRuntimeService
-            }
-            ResourceType::IBMQuantumComputeService => {
-                crate::models::ResourceType::IBMQuantumComputeService
-            }
-            ResourceType::PasqalCloud => crate::models::ResourceType::PasqalCloud,
-            ResourceType::PasqalLocal => crate::models::ResourceType::PasqalLocal,
-            ResourceType::AliceBobFelis => crate::models::ResourceType::AliceBobFelis,
-            ResourceType::IQMServer => crate::models::ResourceType::IQMServer,
-        }
-    }
-}
+// Cross-cutting pieces (the `QrmiError` exception hierarchy, `to_py_err`,
+// and the `ResourceType` <-> `crate::models::ResourceType` conversions)
+// live in `pyext::common` so `pyext_async` can reuse them via `pub(crate)`
+// instead of duplicating them. Re-exported here so existing references to
+// `pyext::ResourceType`, `pyext::EnvVarNotSetError`, etc. keep working
+// unchanged.
+pub(crate) mod common;
+pub use common::{
+    AuthenticationFailedError, ConfigError, EnvVarNotSetError, InvalidInputError, QrmiError_,
+    ResourceNotFoundError, ResourceType, TaskNotFoundError, TaskNotReadyError,
+    UnsupportedPayloadError, UnsupportedResourceTypeError,
+};
+use common::to_py_err;
 
 #[gen_stub_pyclass]
 #[pyclass]
@@ -223,22 +117,7 @@ impl PyQuantumResource {
     fn resource_type(&mut self, py: Python<'_>) -> PyResult<ResourceType> {
         crate::common::initialize();
         let result = py.detach(|| self.rt.block_on(async { self.qrmi.resource_type().await }));
-        match result {
-            Ok(v) => Ok(match v {
-                crate::models::ResourceType::IBMQuantumSystem => ResourceType::IBMQuantumSystem,
-                crate::models::ResourceType::QiskitRuntimeService => {
-                    ResourceType::IBMQiskitRuntimeService
-                }
-                crate::models::ResourceType::IBMQuantumComputeService => {
-                    ResourceType::IBMQuantumComputeService
-                }
-                crate::models::ResourceType::PasqalCloud => ResourceType::PasqalCloud,
-                crate::models::ResourceType::PasqalLocal => ResourceType::PasqalLocal,
-                crate::models::ResourceType::AliceBobFelis => ResourceType::AliceBobFelis,
-                crate::models::ResourceType::IQMServer => ResourceType::IQMServer,
-            }),
-            Err(e) => Err(to_py_err(e)),
-        }
+        result.map(ResourceType::from).map_err(to_py_err)
     }
 
     fn acquire(&mut self, py: Python<'_>) -> PyResult<String> {
@@ -360,19 +239,7 @@ impl PyResourceDef {
     /// Resource type.
     #[getter]
     pub fn resource_type(&self) -> ResourceType {
-        match self.inner.r#type {
-            crate::models::ResourceType::IBMQuantumSystem => ResourceType::IBMQuantumSystem,
-            crate::models::ResourceType::QiskitRuntimeService => {
-                ResourceType::IBMQiskitRuntimeService
-            }
-            crate::models::ResourceType::IBMQuantumComputeService => {
-                ResourceType::IBMQuantumComputeService
-            }
-            crate::models::ResourceType::PasqalCloud => ResourceType::PasqalCloud,
-            crate::models::ResourceType::PasqalLocal => ResourceType::PasqalLocal,
-            crate::models::ResourceType::AliceBobFelis => ResourceType::AliceBobFelis,
-            crate::models::ResourceType::IQMServer => ResourceType::IQMServer,
-        }
+        ResourceType::from(self.inner.r#type.clone())
     }
 
     /// Whether this resource definition is dynamic.
@@ -817,6 +684,8 @@ fn qrmi(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyResourceProvider>()?;
     m.add_class::<PyConfig>()?;
     m.add_class::<PyQRMIService>()?;
+    #[cfg(feature = "pyo3-async")]
+    m.add_class::<crate::pyext_async::PyAsyncQuantumResource>()?;
 
     // Register the QrmiError exception hierarchy so Python code can catch
     // them by name (e.g. `except qrmi.TaskNotReadyError`). `create_exception!`

--- a/src/pyext/common.rs
+++ b/src/pyext/common.rs
@@ -1,0 +1,171 @@
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! Pieces shared between the synchronous (`pyext`) and asyncio-native
+//! (`pyext_async`) Python bindings: the `QrmiError` -> `PyErr` exception
+//! hierarchy and its conversion function, and the `ResourceType`
+//! conversions between the Rust-native (`crate::models::ResourceType`) and
+//! pyo3-facing (`ResourceType`, defined here) enums.
+//!
+//! Pulled out of `pyext.rs` into its own module specifically so a second
+//! binding (`pyext_async`) can reuse it via `pub(crate)` instead of
+//! duplicating it, as it originally had to.
+
+use pyo3::prelude::*;
+use pyo3_stub_gen::{create_exception, derive::*};
+
+use crate::error::{QrmiError, QrmiErrorKind};
+
+create_exception!(
+    qrmi._core,
+    QrmiError_,
+    pyo3::exceptions::PyRuntimeError,
+    "Base class for all QRMI-specific errors. Catching this catches any \
+     error QRMI itself raises (as opposed to errors surfaced verbatim from \
+     an underlying vendor library)."
+);
+create_exception!(
+    qrmi._core,
+    EnvVarNotSetError,
+    QrmiError_,
+    "A required environment variable was not set."
+);
+create_exception!(
+    qrmi._core,
+    ConfigError,
+    QrmiError_,
+    "A configuration value was missing, could not be parsed, or was \
+     otherwise invalid (covers `QrmiError::ParseError`, \
+     `QrmiError::MissingConfigKey`, and `QrmiError::InvalidConfig`)."
+);
+create_exception!(
+    qrmi._core,
+    UnsupportedResourceTypeError,
+    QrmiError_,
+    "Dynamic discovery was requested for an unsupported resource type."
+);
+create_exception!(
+    qrmi._core,
+    UnsupportedPayloadError,
+    QrmiError_,
+    "The payload (or a value within it, such as a program ID) is not \
+     supported by this backend."
+);
+create_exception!(
+    qrmi._core,
+    TaskNotReadyError,
+    QrmiError_,
+    "The task is not in a state that allows the requested operation \
+     (e.g. its result was requested while it is still running)."
+);
+create_exception!(
+    qrmi._core,
+    InvalidInputError,
+    QrmiError_,
+    "A value QRMI was given was invalid, whether QRMI itself rejected it \\
+     locally (e.g. a malformed `filters` string, JSON, or UTF-8) or a \\
+     vendor's API rejected the resulting request after receiving it."
+);
+create_exception!(
+    qrmi._core,
+    ResourceNotFoundError,
+    QrmiError_,
+    "The named resource (e.g. a backend) does not exist."
+);
+create_exception!(
+    qrmi._core,
+    TaskNotFoundError,
+    QrmiError_,
+    "The named task (e.g. a job) does not exist, or has already been removed."
+);
+create_exception!(
+    qrmi._core,
+    AuthenticationFailedError,
+    QrmiError_,
+    "The request's credentials were missing or rejected by the vendor's API."
+);
+
+/// Converts a [`QrmiError`] into the [`PyErr`] subclass matching its kind,
+/// so Python code can `except qrmi.TaskNotReadyError` instead of parsing
+/// `RuntimeError` message text. See `QrmiError::kind` for the mapping.
+///
+/// `pub(crate)`, not private, specifically so both `pyext` and
+/// `pyext_async` can call it without duplicating this match.
+pub(crate) fn to_py_err(err: QrmiError) -> PyErr {
+    let msg = err.to_string();
+    match err.kind() {
+        QrmiErrorKind::EnvVarNotSet => EnvVarNotSetError::new_err(msg),
+        QrmiErrorKind::ParseError
+        | QrmiErrorKind::MissingConfigKey
+        | QrmiErrorKind::InvalidConfig => ConfigError::new_err(msg),
+        QrmiErrorKind::UnsupportedResourceType => UnsupportedResourceTypeError::new_err(msg),
+        QrmiErrorKind::UnsupportedPayload => UnsupportedPayloadError::new_err(msg),
+        QrmiErrorKind::TaskNotReady => TaskNotReadyError::new_err(msg),
+        QrmiErrorKind::InvalidInput => InvalidInputError::new_err(msg),
+        QrmiErrorKind::ResourceNotFound => ResourceNotFoundError::new_err(msg),
+        QrmiErrorKind::TaskNotFound => TaskNotFoundError::new_err(msg),
+        QrmiErrorKind::AuthenticationFailed => AuthenticationFailedError::new_err(msg),
+        QrmiErrorKind::Other => QrmiError_::new_err(msg),
+    }
+}
+
+#[pyclass(eq, eq_int, hash, frozen, from_py_object)]
+#[gen_stub_pyclass_enum]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ResourceType {
+    IBMQuantumSystem,
+    IBMQiskitRuntimeService,
+    IBMQuantumComputeService,
+    PasqalCloud,
+    PasqalLocal,
+    AliceBobFelis,
+    IQMServer,
+}
+
+impl From<ResourceType> for crate::models::ResourceType {
+    fn from(value: ResourceType) -> Self {
+        match value {
+            ResourceType::IBMQuantumSystem => crate::models::ResourceType::IBMQuantumSystem,
+            ResourceType::IBMQiskitRuntimeService => {
+                crate::models::ResourceType::QiskitRuntimeService
+            }
+            ResourceType::IBMQuantumComputeService => {
+                crate::models::ResourceType::IBMQuantumComputeService
+            }
+            ResourceType::PasqalCloud => crate::models::ResourceType::PasqalCloud,
+            ResourceType::PasqalLocal => crate::models::ResourceType::PasqalLocal,
+            ResourceType::AliceBobFelis => crate::models::ResourceType::AliceBobFelis,
+            ResourceType::IQMServer => crate::models::ResourceType::IQMServer,
+        }
+    }
+}
+
+// The reverse direction. Previously this exact match was inlined by hand
+// in both `pyext::PyQuantumResource::resource_type` and
+// `pyext_async::PyAsyncQuantumResource::resource_type` -- now there is
+// exactly one copy, reusable via `.into()` from both.
+impl From<crate::models::ResourceType> for ResourceType {
+    fn from(value: crate::models::ResourceType) -> Self {
+        match value {
+            crate::models::ResourceType::IBMQuantumSystem => ResourceType::IBMQuantumSystem,
+            crate::models::ResourceType::QiskitRuntimeService => {
+                ResourceType::IBMQiskitRuntimeService
+            }
+            crate::models::ResourceType::IBMQuantumComputeService => {
+                ResourceType::IBMQuantumComputeService
+            }
+            crate::models::ResourceType::PasqalCloud => ResourceType::PasqalCloud,
+            crate::models::ResourceType::PasqalLocal => ResourceType::PasqalLocal,
+            crate::models::ResourceType::AliceBobFelis => ResourceType::AliceBobFelis,
+            crate::models::ResourceType::IQMServer => ResourceType::IQMServer,
+        }
+    }
+}

--- a/src/pyext_async.rs
+++ b/src/pyext_async.rs
@@ -1,0 +1,174 @@
+//
+// (C) Copyright IBM 2026
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+//! asyncio-native counterpart to [`crate::pyext`], built on
+//! `pyo3-async-runtimes`.
+//!
+//! Cross-cutting pieces (`to_py_err`, the `QrmiError_` exception
+//! hierarchy, `ResourceType` and its conversions) live in
+//! [`crate::pyext::common`], `pub(crate)`, specifically so this module can
+//! reuse them instead of duplicating them.
+
+use std::sync::Arc;
+
+use pyo3::prelude::*;
+use pyo3_stub_gen::derive::*;
+use tokio::sync::Mutex;
+
+use crate::models::Payload;
+use crate::pyext::common::{to_py_err, ResourceType};
+use crate::QuantumResource;
+
+/// asyncio-native counterpart to `pyext::PyQuantumResource`.
+///
+/// Every I/O method returns a Python coroutine (via
+/// `pyo3_async_runtimes::tokio::future_into_py`) instead of blocking the
+/// calling thread, so this is meant to be awaited from an asyncio event
+/// loop: `await resource.is_accessible()`, etc.
+///
+/// Unlike `PyQuantumResource`, this type does not own a per-instance
+/// `tokio::runtime::Runtime`: `future_into_py` schedules work on the single
+/// process-wide runtime `pyo3-async-runtimes` lazily creates on first use
+/// (`pyo3_async_runtimes::tokio::get_runtime()`), so the two bindings can
+/// coexist without either owning the other's runtime.
+#[gen_stub_pyclass]
+#[pyclass]
+#[pyo3(name = "AsyncQuantumResource")]
+pub struct PyAsyncQuantumResource {
+    // `Arc<Mutex<..>>`, not a bare `Box`, because every method below has to
+    // hand `future_into_py` a `'static` future: the future must own (or
+    // share ownership of) the resource rather than borrow `&mut self`,
+    // since `self` does not outlive the call that creates the coroutine.
+    // `tokio::sync::Mutex`, not `std::sync::Mutex`, because its guard is
+    // `Send`, which is required since the guard is held across the `.await`
+    // points inside the trait's own async methods.
+    qrmi: Arc<Mutex<Box<dyn QuantumResource + Send + Sync>>>,
+}
+
+impl PyAsyncQuantumResource {
+    /// Internal constructor used by `PyAsyncQRMIService::create()`.
+    pub(crate) fn from_inner(qrmi: Box<dyn QuantumResource + Send + Sync>) -> Self {
+        Self {
+            qrmi: Arc::new(Mutex::new(qrmi)),
+        }
+    }
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyAsyncQuantumResource {
+    #[new]
+    pub fn new(resource_id: &str, resource_type: ResourceType) -> PyResult<Self> {
+        crate::common::initialize();
+        let qrmi = crate::common::create_resource(&resource_type.into(), resource_id)
+            .map_err(to_py_err)?;
+        Ok(Self::from_inner(qrmi))
+    }
+
+    fn is_accessible<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.is_accessible().await.map_err(to_py_err)
+        })
+    }
+
+    fn resource_id<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.resource_id().await.map_err(to_py_err)
+        })
+    }
+
+    fn resource_type<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.resource_type()
+                .await
+                .map(ResourceType::from)
+                .map_err(to_py_err)
+        })
+    }
+
+    fn acquire<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.acquire().await.map_err(to_py_err)
+        })
+    }
+
+    fn release<'py>(&self, py: Python<'py>, id: String) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.release(&id).await.map_err(to_py_err)
+        })
+    }
+
+    fn task_start<'py>(&self, py: Python<'py>, payload: Payload) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.task_start(payload).await.map_err(to_py_err)
+        })
+    }
+
+    fn task_stop<'py>(&self, py: Python<'py>, task_id: String) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.task_stop(&task_id).await.map_err(to_py_err)
+        })
+    }
+
+    fn task_status<'py>(&self, py: Python<'py>, task_id: String) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.task_status(&task_id).await.map_err(to_py_err)
+        })
+    }
+
+    fn task_result<'py>(&self, py: Python<'py>, task_id: String) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.task_result(&task_id).await.map_err(to_py_err)
+        })
+    }
+
+    fn task_logs<'py>(&self, py: Python<'py>, task_id: String) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.task_logs(&task_id).await.map_err(to_py_err)
+        })
+    }
+
+    fn target<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            qrmi.target().await.map_err(to_py_err)
+        })
+    }
+
+    fn metadata<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let qrmi = self.qrmi.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut qrmi = qrmi.lock().await;
+            Ok::<_, PyErr>(qrmi.metadata().await)
+        })
+    }
+}


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
(Editted) To reviewers, 

This feature was originally added for a new QRMI vendor implementation I was preparing. However, after further discussions, we no longer have an immediate use case for it. If you still see value in this feature, please review and approve the PR. Otherwise, feel free to close it

### Summary

Adds an asyncio-native counterpart to the existing `QuantumResource` Python binding, built on `pyo3-async-runtimes`. Every I/O method (`is_accessible`, `acquire`, `release`, `task_start`, `task_status`, `task_result`, `task_logs`, `task_stop`, `target`, `metadata`, `resource_id`, `resource_type`) returns an `asyncio.Future` instead of blocking the calling thread, so it can be `await`ed from an asyncio event loop and multiple resources can be driven concurrently with `asyncio.gather`.

```python
import asyncio
from qrmi import AsyncQuantumResource, ResourceType

async def main():
    r = AsyncQuantumResource("ibm_torino", ResourceType.IBMQuantumSystem)
    if await r.is_accessible():
        lock = await r.acquire()
        ...

asyncio.run(main())
```

### Motivation

The existing `QuantumResource` binding blocks the calling thread for every I/O call (it drives its own per-instance tokio `Runtime` via `py.detach()`+`block_on()`). That's fine for a single script that submits one job and waits, but it has two real gaps:

- **Embedding in an asyncio app.** Anything already built on asyncio (an aiohttp/FastAPI service orchestrating QPU jobs, for instance) has to wrap every QRMI call in `loop.run_in_executor(...)` to avoid blocking its event loop. That's boilerplate that's easy to forget at one call site and get a stalled event loop for it.
- **Integrating with vendor SDKs that are themselves asyncio-based.** Some quantum vendor SDKs are implemented on top of asyncio. Mixing those with a blocking QRMI call means either wrapping QRMI in `run_in_executor` or wrapping the vendor SDK in its own thread — either way, two different concurrency models bolted together in the same program. An asyncio-native QRMI binding lets both sides `await` on the same event loop directly.
- **Concurrency across multiple resources.** Running the same workload against several backends at once currently means reaching for `threading`/`concurrent.futures` alongside the sync binding. `asyncio.gather` over several of these resources works today.

To be clear about what this *isn't*: it isn't a performance optimization for the common single-backend, single-job case, and by itself it doesn't make any individual QRMI call faster. Two different `AsyncQuantumResource` instances do run truly concurrently (see Design notes), but calls on the *same* instance still serialize through the underlying resource, exactly
as with the sync binding — this is about *not blocking the caller* and *composing cleanly with asyncio*, not about parallelizing work that was sequential before.

## What's added

- **`src/pyext_async.rs`** (new file) — the `AsyncQuantumResource` pyclass. Wraps the resource in `Arc<tokio::sync::Mutex<Box<dyn QuantumResource + Send + Sync>>>` so each method can hand `pyo3_async_runtimes`'s `future_into_py` a `'static` future without needing `&mut self` to outlive the call. Doesn't own a per-instance tokio `Runtime` like the sync binding does; it schedules work on the single process-wide runtime
  `pyo3-async-runtimes` lazily creates.
- **`src/pyext/common.rs`** (new file) — the `QrmiError` -> `PyErr`  exception hierarchy, `to_py_err`, and the `ResourceType` conversions (both directions), pulled out of `pyext.rs` so `pyext_async.rs` can reuse them via `pub(crate)` instead of duplicating them. Also newly adds a proper `impl From<crate::models::ResourceType> for ResourceType` for
  the reverse direction, which previously had to be hand-inlined at each of its two call sites in `pyext.rs`.
- **New Cargo feature `pyo3-async`** (`Cargo.toml`), separate from the existing `pyo3` feature, so existing consumers of the sync API aren't forced to pull in `pyo3-async-runtimes` + a global tokio runtime.
- **`src/lib.rs`**: `#[cfg(feature = "pyo3-async")] pub mod pyext_async;`
- **`src/pyext.rs`**: refactored, not just appended to. The exception hierarchy, `to_py_err`, and `ResourceType`'s definition moved out into `pyext::common` (see above); the two remaining call sites
  (`PyQuantumResource::resource_type` and `PyResourceDef::resource_type`) now call `ResourceType::from(...)` instead of repeating the match by hand. The one line actually *added* (not moved) is the new class registration in the existing `#[pymodule] fn qrmi(...)`.
- **Examples** (`examples/qrmi/python/async/`):
  - `async_example.py` — asyncio port of the existing IBM Quantum System example
  - `is_accessible_concurrent.py` — checks `is_accessible()` on multiple backends concurrently via `asyncio.gather`
  - `task_run_concurrent.py` — submits a task to multiple backends concurrently (one input file + one program id per backend, paired via repeated `--backend`/`--input`/`--program-id` flags), polls each independently, and collects all results (or per-backend errors, via `return_exceptions=True`)

### Design notes

- Two different `AsyncQuantumResource` instances run truly concurrently (independent `Arc<Mutex<..>>`, shared multi-threaded tokio runtime); concurrent calls on the *same* instance still serialize through its internal mutex, matching the existing single-instance semantics of the sync binding.
- No changes to the `QuantumResource` trait, `models`, or any existing provider implementation (IBM/Pasqal/IQM/Alice&Bob) — this is purely an additive binding layer plus a same-crate refactor to avoid duplicating
  error/type conversion logic across the two bindings.
  
### Testing

- `cargo build --release
- `maturin build --release`, installed into a venv, confirmed `AsyncQuantumResource` is importable and functionally
  equivalent to the sync API against a real IBM Quantum System backend (`is_accessible`, `acquire`/`release`, `task_start` → poll `task_status` → `task_result`/`task_logs` → `task_stop`)
- Ran `is_accessible_concurrent.py` and `task_run_concurrent.py` against multiple real backends concurrently
- Ran existing 'sync' python examples against real backends

## Checklist ✅

- [x] Have you included a description of this change?
- [ ] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
