### PR TITLE
[IQM] Adapt to Health Status API Changes

### DIFF
--- a/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
+++ b/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
@@ -28,10 +28,19 @@ use serde::{Deserialize, Serialize};
 /// enough without touching that function. Revert this patch once the crate
 /// is regenerated from an OpenAPI spec that reflects the server's current
 /// response shape.
+
+fn default_operational() -> String {
+    "online".to_string()
+}
+
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IqmServerQcHealthStatus {
     /// Whether the quantum computer is currently accepting jobs.
-    #[serde(rename = "operational")]
+    #[serde(
+        rename = "operational",
+        alias = "operational_status",
+        default = "default_operational"
+    )]
     pub operational: String,
     #[serde(rename = "health")]
     pub health: Box<models::QcHealthDetail>,

--- a/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
+++ b/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
@@ -29,6 +29,13 @@ use serde::{Deserialize, Serialize};
 /// is regenerated from an OpenAPI spec that reflects the server's current
 /// response shape.
 
+/// Returns the fallback value for the operational field when the key is
+/// absent from the response payload entirely.
+///
+/// Older IQM server versions predate the introduction of operational/operational_status
+/// and never include either key. In that case we assume the quantum computer
+/// is operational, since these older servers did not expose a mechanism to
+/// report otherwise.
 fn default_operational() -> String {
     "online".to_string()
 }

--- a/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
+++ b/dependencies/iqm_client/src/models/iqm_server_qc_health_status.rs
@@ -15,6 +15,16 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// Returns the fallback value for the operational field when the key is
+/// absent from the response payload entirely.
+/// Older IQM server versions predate the introduction of operational/operational_status
+/// and never include either key. In that case we assume the quantum computer
+/// is operational, since these older servers did not expose a mechanism to
+/// report otherwise.
+fn default_operational() -> String {
+    "online".to_string()
+}
+
 /// IqmServerQcHealthStatus : The current computer health status.
 ///
 /// NOTE: hand-patched, not regenerated from the OpenAPI spec. The live IQM
@@ -28,18 +38,6 @@ use serde::{Deserialize, Serialize};
 /// enough without touching that function. Revert this patch once the crate
 /// is regenerated from an OpenAPI spec that reflects the server's current
 /// response shape.
-
-/// Returns the fallback value for the operational field when the key is
-/// absent from the response payload entirely.
-///
-/// Older IQM server versions predate the introduction of operational/operational_status
-/// and never include either key. In that case we assume the quantum computer
-/// is operational, since these older servers did not expose a mechanism to
-/// report otherwise.
-fn default_operational() -> String {
-    "online".to_string()
-}
-
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IqmServerQcHealthStatus {
     /// Whether the quantum computer is currently accepting jobs.

--- a/examples/qrmi/lua/iqm/README.md
+++ b/examples/qrmi/lua/iqm/README.md
@@ -26,7 +26,7 @@ Because QRMI is an environment variable driven software library, all configurati
 | Environment variables | Descriptions |
 | ---- | ---- |
 | {qc_alias_name}_QRMI_IQM_ISA_ENDPOINT | IQM Server API endpoint |
-| {qc_alias_name}_QRMI_IBM_ISA_TOKEN | IQM Server API token |
+| {qc_alias_name}_QRMI_IQM_ISA_TOKEN | IQM Server API token |
 
 > [!NOTE]
 > Replace the “:” in the QC alias name with “_” when specifying it. For example, `sirius:mock` -> `sirius_mock`.


### PR DESCRIPTION
## Description of Change

<!-- Please include a readable description about the change. -->
### Background

IQM has been changing the response schema of the Health Status API frequently. PR #213 added support for the newly introduced `operational` field, but this week the field name was changed to `operational_status`. In addition, the
quantum computer at Oak Ridge National Laboratory still runs an older server version that predates the introduction of these fields entirely. As a result, we now need to support all three payload variants simultaneously:

1. The `operational` key is absent entirely

```
{
  "health": {
    "healthy": true,
    "updated_at": "2026-09-04T23:08:52.613Z"
  }
}
```

2. The `operational` key is present

```
{
  "operational": "online",
  "health": {
    "healthy": true,
    "updated_at": "2026-09-04T23:08:52.613Z"
  }
}
```

3. The `operational_status` key is present instead of `operational`

```
{
  "operational_status": "online",
  "health": {
    "healthy": true,
    "updated_at": "2026-09-04T23:08:52.613Z"
  }
}
```

### Solution
Merge `operational` and `operational_status` into a single field (`operational: String`) and use `alias` plus `default` to handle all three payload shapes:

```rust
fn default_operational() -> String {
    "online".to_string()
}

#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct IqmServerQcHealthStatus {
    /// Whether the quantum computer is currently accepting jobs.
    #[serde(
        rename = "operational",
        alias = "operational_status",
        default = "default_operational"
    )]
    pub operational: String,

    #[serde(rename = "health")]
    pub health: Box<models::QcHealthDetail>,
}
```

- `rename = "operational"` matches payloads where the key is `operational`.
- `alias = "operational_status"` additionally matches payloads where the key is `operational_status`, mapping it onto the same field.
- `default = "default_operational"` supplies `"online"` when neither key is present at all (older server versions, e.g. Oak Ridge).

### Alternative considered
Branching behavior on API version was considered, but rejected: the IQM API reports the same API version across all three of these payload variants, so version cannot be used to distinguish them.

### Testing
- [x] Deserialize a payload containing only `operational` and verify the value is captured correctly
- [x] Deserialize a payload containing only `operational_status` and verify it maps to `operational`
- [x] Deserialize a payload containing neither key and verify `operational` defaults to `"online"`
- [x] Confirm existing serialization tests still pass

### User impacts
- Users(system administrator) need to re-build their spank-plugin with the latest QRMI source code and deploy. 

## Checklist ✅

- [x] Have you included a description of this change?
- [x] Have you updated the relevant documentation to reflect this change?
- [x] Have you made sure CI is passing before requesting a review?

## Ticket
- [ ] Fixes #
- [ ] Is Part of #
